### PR TITLE
[FIX] Ensure fieldmaps are handled correctly around eddy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -194,7 +194,7 @@ jobs:
           name: Check Python version and upgrade pip
           command: |
             python --version
-            python -m pip install -U pip
+            python -m pip install -U pip numpy
       - run:
           name: Install graphviz
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -199,7 +199,7 @@ jobs:
           name: Install graphviz
           command: |
               apt-get update
-              apt-get install -y graphviz numpy
+              apt-get install -y graphviz
       - run:
           name: Install qsiprep.
           command: python -m pip install ".[doc]" --no-cache-dir --progress-bar off

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -177,7 +177,7 @@ jobs:
 
   build_docs:
     docker:
-        - image: python:latest
+        - image: python:3.7.5-stretch
     working_directory: /tmp/src/qsiprep
     environment:
       - FSLOUTPUTTYPE: 'NIFTI'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -199,7 +199,7 @@ jobs:
           name: Install graphviz
           command: |
               apt-get update
-              apt-get install -y graphviz
+              apt-get install -y graphviz numpy
       - run:
           name: Install qsiprep.
           command: python -m pip install ".[doc]" --no-cache-dir --progress-bar off

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -6,9 +6,14 @@
       "orcid": "0000-0002-1931-4734"
     },
     {
-    "name": "Sydnor, Valerie Jill",
-    "affiliation": "Perelman School of Medicine, University of Pennsylvania",
-    "orcid": "0000-0002-8640-668X"
+      "name": "Sydnor, Valerie Jill",
+      "affiliation": "Perelman School of Medicine, University of Pennsylvania",
+      "orcid": "0000-0002-8640-668X"
+    },
+    {
+      "name": "He, Xiaosong",
+      "affiliation": "Department of Bioengineering, University of Pennsylvania",
+      "orcid": "0000-0002-7941-2918"
     }
   ],
   "keywords": [

--- a/qsiprep/interfaces/images.py
+++ b/qsiprep/interfaces/images.py
@@ -24,7 +24,7 @@ from nipype.interfaces import fsl
 #from qsiprep.interfaces.images import (
 #    nii_ones_like, extract_wm, SignalExtraction, MatchHeader,
 #    FilledImageLike, DemeanImage, TemplateDimensions)
-from ..niworkflows.interfaces.images import ValidateImageInputSpec, ValidateImageOutputSpec
+from ..niworkflows.interfaces.images import ValidateImageInputSpec
 from nipype.interfaces.afni.base import AFNICommand, AFNICommandInputSpec, AFNICommandOutputSpec
 
 LOGGER = logging.getLogger('nipype.interface')
@@ -343,6 +343,7 @@ class Conform(SimpleInterface):
 
 class ConformDwiInputSpec(BaseInterfaceInputSpec):
     dwi_file = File(exists=True, mandatory=True, desc='dwi image')
+    orientation = traits.Enum('LPS', 'LAS', default='LPS', usedefault=True)
 
 
 class ConformDwiOutputSpec(TraitedSpec):
@@ -357,7 +358,7 @@ class ConformDwi(SimpleInterface):
 
     Performs three basic functions:
 
-    #. Orient to LPS (right-left, anterior-posterior, inferior-superior)
+    #. Orient image to requested orientation
     #. Flip bvecs accordingly
     #. Do nothing to the bvals
 
@@ -368,39 +369,47 @@ class ConformDwi(SimpleInterface):
 
     def _run_interface(self, runtime):
         fname = self.inputs.dwi_file
-        out_fname = fname_presuffix(fname, suffix='_lps', newpath=runtime.cwd)
+        orientation = self.inputs.orientation
+        suffix = "_" + orientation
+        out_fname = fname_presuffix(fname, suffix=suffix, newpath=runtime.cwd)
         bvec_fname = fname_presuffix(fname, suffix=".bvec", use_ext=False)
         bval_fname = fname_presuffix(fname, suffix=".bval", use_ext=False)
-        out_bvec_fname = fname_presuffix(bvec_fname, suffix='_lps', newpath=runtime.cwd)
+        out_bvec_fname = fname_presuffix(bvec_fname, suffix=suffix, newpath=runtime.cwd)
         input_img = nb.load(fname)
         input_axcodes = nb.aff2axcodes(input_img.affine)
         # Is the input image oriented how we want?
-        new_axcodes = ('L', 'P', 'S')
+        new_axcodes = tuple(orientation)
+
         if not input_axcodes == new_axcodes:
             # Re-orient
+            LOGGER.info("Re-orienting %s to %s", fname, orientation)
             input_orientation = nb.orientations.axcodes2ornt(input_axcodes)
             desired_orientation = nb.orientations.axcodes2ornt(new_axcodes)
             transform_orientation = nb.orientations.ornt_transform(
-                        input_orientation, desired_orientation)
+                input_orientation, desired_orientation)
             reoriented_img = input_img.as_reoriented(transform_orientation)
             reoriented_img.to_filename(out_fname)
-
-            # Flip the bvecs
-            bvec_array = np.loadtxt(bvec_fname)
-            if not bvec_array.shape[0] == transform_orientation.shape[0]:
-                raise ValueError("Unrecognized bvec format")
-            output_array = np.zeros_like(bvec_array)
-            for this_axnum, (axnum, flip) in enumerate(transform_orientation):
-                output_array[this_axnum] = bvec_array[int(axnum)] * flip
-            np.savetxt(out_bvec_fname, output_array, fmt="%.8f ")
-            self._results['bvec_file'] = out_bvec_fname
             self._results['dwi_file'] = out_fname
 
-        else:
-            self._results['dwi_file'] = fname
-            self._results['bvec_file'] = bvec_fname
+            # Flip the bvecs
+            if os.path.exists(bvec_fname):
+                LOGGER.info('Reorienting %s to %s', bvec_fname, orientation)
+                bvec_array = np.loadtxt(bvec_fname)
+                if not bvec_array.shape[0] == transform_orientation.shape[0]:
+                    raise ValueError("Unrecognized bvec format")
+                output_array = np.zeros_like(bvec_array)
+                for this_axnum, (axnum, flip) in enumerate(transform_orientation):
+                    output_array[this_axnum] = bvec_array[int(axnum)] * flip
+                np.savetxt(out_bvec_fname, output_array, fmt="%.8f ")
+                self._results['bvec_file'] = out_bvec_fname
+                self._results['bval_file'] = bval_fname
 
-        self._results['bval_file'] = bval_fname
+        else:
+            LOGGER.info("Not applying reorientation to %s: already in %s", fname, orientation)
+            self._results['dwi_file'] = fname
+            if os.path.exists(bvec_fname):
+                self._results['bvec_file'] = bvec_fname
+                self._results['bval_file'] = bval_fname
 
         return runtime
 
@@ -557,9 +566,15 @@ def reorient(in_file, newpath=None):
     to_lps(nb.load(in_file)).to_filename(out_file)
     return out_file
 
+def reorient_to(in_file, orientation="LPS", newpath=None):
+    out_file = fname_presuffix(in_file, suffix='_'+orientation, newpath=newpath)
+    to_lps(in_file, tuple(orientation)).to_filename(out_file)
+    return out_file
 
-def to_lps(input_img):
-    new_axcodes = ("L", "P", "S")
+
+def to_lps(input_img, new_axcodes=("L", "P", "S")):
+    if isinstance(input_img, str):
+        input_img = nb.load(input_img)
     input_axcodes = nb.aff2axcodes(input_img.affine)
     # Is the input image oriented how we want?
     if not input_axcodes == new_axcodes:

--- a/qsiprep/workflows/dwi/base.py
+++ b/qsiprep/workflows/dwi/base.py
@@ -302,6 +302,7 @@ def init_dwi_preproc_wf(scan_groups,
                                      b0_threshold=b0_threshold,
                                      preprocess_rpe_series=preprocess_rpe_series,
                                      dwi_denoise_window=dwi_denoise_window,
+                                     orientation='LAS' if hmc_model == 'eddy' else 'LPS',
                                      low_mem=low_mem,
                                      denoise_before_combining=denoise_before_combining,
                                      omp_nthreads=omp_nthreads)

--- a/qsiprep/workflows/dwi/finalize.py
+++ b/qsiprep/workflows/dwi/finalize.py
@@ -11,23 +11,17 @@ import os
 from nipype import logging
 
 from nipype.pipeline import engine as pe
-from nipype.interfaces import afni, mrtrix3, utility as niu
+from nipype.interfaces import afni, utility as niu
 
 from ...interfaces import DerivativesDataSink
 from ...niworkflows.interfaces.registration import SimpleBeforeAfterRPT
-from ...interfaces.reports import DiffusionSummary, GradientPlot
-from ...interfaces.confounds import DMRISummary
+from ...interfaces.reports import GradientPlot
 from ...interfaces.mrtrix import MRTrixGradientTable
 from ...engine import Workflow
 
 # dwi workflows
-from .hmc_sdc import init_qsiprep_hmcsdc_wf
-from .fsl import init_fsl_hmc_wf
-from .pre_hmc import init_dwi_pre_hmc_wf
-from .util import _create_mem_gb, _get_wf_name
-from .registration import init_b0_to_anat_registration_wf
+from .util import _create_mem_gb
 from .resampling import init_dwi_trans_wf
-from .confounds import init_dwi_confs_wf
 from .derivatives import init_dwi_derivatives_wf
 
 DEFAULT_MEMORY_MIN_GB = 0.01

--- a/qsiprep/workflows/dwi/fsl.py
+++ b/qsiprep/workflows/dwi/fsl.py
@@ -179,7 +179,6 @@ def init_fsl_hmc_wf(scan_groups,
             (unwarped_enhance, eddy, [
                 ('outputnode.mask_file', 'in_mask')]),
             (topup, eddy, [
-                ('out_movpar', 'in_topup_movpar'),
                 ('out_field', 'field')])])
     elif fieldmap_type in ('fieldmap', 'phasediff', 'phase', 'syn'):
         outputnode.inputs.sdc_method = fieldmap_type

--- a/qsiprep/workflows/dwi/fsl.py
+++ b/qsiprep/workflows/dwi/fsl.py
@@ -159,7 +159,7 @@ def init_fsl_hmc_wf(scan_groups,
         gather_inputs.inputs.rpe_b0 = rpe_b0
         prepare_rpe_b0 = pe.Node(B0RPEFieldmap(b0_file=rpe_b0), name="prepare_rpe_b0")
 
-        topup = pe.Node(fsl.TOPUP(), name="topup")
+        topup = pe.Node(fsl.TOPUP(out_field="fieldmap_HZ.nii.gz"), name="topup")
         unwarped_mean = pe.Node(afni.TStat(outputtype='NIFTI_GZ'), name='unwarped_mean')
         unwarped_enhance = init_enhance_and_skullstrip_dwi_wf(name='unwarped_enhance')
 
@@ -180,7 +180,7 @@ def init_fsl_hmc_wf(scan_groups,
                 ('outputnode.mask_file', 'in_mask')]),
             (topup, eddy, [
                 ('out_movpar', 'in_topup_movpar'),
-                ('out_fieldcoef', 'in_topup_fieldcoef')])])
+                ('out_field', 'field')])])
     elif fieldmap_type in ('fieldmap', 'phasediff', 'phase', 'syn'):
         outputnode.inputs.sdc_method = fieldmap_type
         b0_enhance = init_enhance_and_skullstrip_dwi_wf(name='b0_enhance')

--- a/qsiprep/workflows/dwi/fsl.py
+++ b/qsiprep/workflows/dwi/fsl.py
@@ -151,9 +151,12 @@ def init_fsl_hmc_wf(scan_groups,
             ('out_dwi', 'in_file'),
             ('out_bval', 'in_bval'),
             ('out_bvec', 'in_bvec')]),
-        #(gather_inputs, outputnode, [
-        #    ('pre_topup_image', 'pre_sdc_template')]),
-        (eddy, back_to_lps, [('out_corrected', 'dwi_file')]),
+        (gather_inputs, outputnode, [
+            ('pre_topup_image', 'pre_sdc_template')]),
+        (eddy, back_to_lps, [
+            ('out_corrected', 'dwi_file'),
+            ('out_rotated_bvecs', 'bvec_file')]),
+        (dwi_merge, back_to_lps, [('out_bval', 'bval_file')]),
         (back_to_lps, split_eddy_lps, [
             ('dwi_file', 'dwi_file'),
             ('bval_file', 'bval_file'),
@@ -181,6 +184,7 @@ def init_fsl_hmc_wf(scan_groups,
         rpe_b0 = scan_groups['fieldmap_info']['rpe_series'][0]
     using_topup = rpe_b0 is not None
 
+    # SyN is the only option that creates warps to the reference. Eddy does the others
     if not fieldmap_type == 'syn':
         workflow.connect([
             (gather_inputs, outputnode, [

--- a/qsiprep/workflows/dwi/fsl.py
+++ b/qsiprep/workflows/dwi/fsl.py
@@ -20,8 +20,9 @@ from nipype.interfaces import fsl, afni, ants
 from ...interfaces import DerivativesDataSink
 from ...interfaces.eddy import GatherEddyInputs, ExtendedEddy, Eddy2SPMMotion
 from ...interfaces.dwi_merge import MergeDWIs
-from ...interfaces.images import SplitDWIs
+from ...interfaces.images import SplitDWIs, ConformDwi
 from ...interfaces.fmap import B0RPEFieldmap
+from ...interfaces.gradients import ExtractB0s
 from ...engine import Workflow
 
 # dwi workflows
@@ -52,8 +53,19 @@ def init_fsl_hmc_wf(scan_groups,
     """
     This workflow controls the dwi preprocessing stages using FSL tools.
 
+    I couldn't get this to work reliably unless everything was oriented in LAS+ before going to
+    TOPUP and eddy. For this reason, if TOPUP is going to be used (for an epi fieldmap or an
+    RPE series) or there is no fieldmap correction, operations occurring before eddy are done in
+    LAS+. The fieldcoefs are applied during eddy's run and the corrected series comes out.
+    This is finally converted to LPS+ and sent to the rest of the pipeline.
+
+    If a GRE fieldmap is available, a fieldmap in Hz is calculated and sent to eddy.
+
+    Finally, if SyN is chosen, it is applied to the LPS+ converted, eddy-resampled data.
+
 
     **Parameters**
+
         scan_groups: dict
             dictionary with fieldmaps and warp space information for the dwis
         impute_slice_threshold: float
@@ -81,10 +93,6 @@ def init_fsl_hmc_wf(scan_groups,
         original_files: list
             List of the files from which each DWI volume came from.
 
-    **Outputs**
-
-
-    **Subworkflows**
 
     """
 
@@ -113,11 +121,16 @@ def init_fsl_hmc_wf(scan_groups,
     with open(eddy_cfg_file, "r") as f:
         eddy_args = json.load(f)
 
-    eddy = pe.Node(ExtendedEddy(**eddy_args), name="eddy")
+    # These should be in LAS+
     dwi_merge = pe.Node(MergeDWIs(), name="dwi_merge")
+    eddy = pe.Node(ExtendedEddy(**eddy_args), name="eddy")
     spm_motion = pe.Node(Eddy2SPMMotion(), name="spm_motion")
+    # Convert eddy outputs back to LPS+, split them
+    back_to_lps = pe.Node(ConformDwi(orientation="LPS"), name='back_to_lps')
+    split_eddy_lps = pe.Node(SplitDWIs(b0_threshold=b0_threshold), name="split_eddy_lps")
 
     workflow.connect([
+        # These images and gradients should be in LAS+
         (inputnode, gather_inputs, [
             ('dwi_files', 'dwi_files'),
             ('bval_files', 'bval_files'),
@@ -125,6 +138,7 @@ def init_fsl_hmc_wf(scan_groups,
             ('b0_indices', 'b0_indices'),
             ('b0_images', 'b0_images'),
             ('original_files', 'original_files')]),
+        # Re-concatenate
         (inputnode, dwi_merge, [
             ('dwi_files', 'dwi_files'),
             ('bval_files', 'bval_files'),
@@ -137,9 +151,27 @@ def init_fsl_hmc_wf(scan_groups,
             ('out_dwi', 'in_file'),
             ('out_bval', 'in_bval'),
             ('out_bvec', 'in_bvec')]),
-        (gather_inputs, outputnode, [
-            ('pre_topup_image', 'pre_sdc_template')])])
+        #(gather_inputs, outputnode, [
+        #    ('pre_topup_image', 'pre_sdc_template')]),
+        (eddy, back_to_lps, [('out_corrected', 'dwi_file')]),
+        (back_to_lps, split_eddy_lps, [
+            ('dwi_file', 'dwi_file'),
+            ('bval_file', 'bval_file'),
+            ('bvec_file', 'bvec_file')]),
+        (dwi_merge, outputnode, [
+            ('original_images', 'original_files')]),
+        (split_eddy_lps, outputnode, [
+            ('dwi_files', 'dwi_files_to_transform'),
+            ('bvec_files', 'bvec_files_to_transform')]),
+        (eddy, outputnode, [
+            (slice_quality, 'slice_quality'),
+            ('out_cnr_maps', 'cnr_map'),
+            (slice_quality, 'hmc_optimization_data')]),
+        (eddy, spm_motion, [('out_parameter', 'eddy_motion')]),
+        (spm_motion, outputnode, [('spm_motion_file', 'motion_params')])
+    ])
 
+    # Fieldmap correction to be done in LAS+: TOPUP or GRE
     # If a topupref is provided, use it for TOPUP
     rpe_b0 = None
     fieldmap_type = scan_groups['fieldmap_info']['suffix']
@@ -147,6 +179,7 @@ def init_fsl_hmc_wf(scan_groups,
         rpe_b0 = scan_groups['fieldmap_info']['epi']
     elif fieldmap_type == 'rpe_series':
         rpe_b0 = scan_groups['fieldmap_info']['rpe_series'][0]
+    using_topup = rpe_b0 is not None
 
     if not fieldmap_type == 'syn':
         workflow.connect([
@@ -154,11 +187,13 @@ def init_fsl_hmc_wf(scan_groups,
                 ('forward_warps', 'to_dwi_ref_warps'),
                 ('forward_transforms', 'to_dwi_ref_affines')])])
 
-    if rpe_b0 is not None:
+    if using_topup:
         outputnode.inputs.sdc_method = "TOPUP"
-        gather_inputs.inputs.rpe_b0 = rpe_b0
-        prepare_rpe_b0 = pe.Node(B0RPEFieldmap(b0_file=rpe_b0), name="prepare_rpe_b0")
-
+        # Whether an rpe series (from dwi/) or an epi fmap (in fmap/) extract just the
+        # b=0s for topup
+        prepare_rpe_b0 = pe.Node(
+            B0RPEFieldmap(b0_file=rpe_b0, orientation='LAS', output_3d_images=False),
+            name="prepare_rpe_b0")
         topup = pe.Node(fsl.TOPUP(out_field="fieldmap_HZ.nii.gz"), name="topup")
         unwarped_mean = pe.Node(afni.TStat(outputtype='NIFTI_GZ'), name='unwarped_mean')
         unwarped_enhance = init_enhance_and_skullstrip_dwi_wf(name='unwarped_enhance')
@@ -172,15 +207,12 @@ def init_fsl_hmc_wf(scan_groups,
                 ('topup_config', 'config')]),
             (topup, unwarped_mean, [('out_corrected', 'in_file')]),
             (unwarped_mean, unwarped_enhance, [('out_file', 'inputnode.in_file')]),
-            (unwarped_enhance, outputnode, [
-                ('outputnode.skull_stripped_file', 'b0_template')]),
-            (unwarped_enhance, outputnode, [
-                ('outputnode.mask_file', 'b0_template_mask')]),
             (unwarped_enhance, eddy, [
                 ('outputnode.mask_file', 'in_mask')]),
             (topup, eddy, [
                 ('out_field', 'field')])])
-    elif fieldmap_type in ('fieldmap', 'phasediff', 'phase', 'syn'):
+
+    elif fieldmap_type in ('fieldmap', 'phasediff', 'phase'):
         outputnode.inputs.sdc_method = fieldmap_type
         b0_enhance = init_enhance_and_skullstrip_dwi_wf(name='b0_enhance')
         b0_sdc_wf = init_sdc_wf(
@@ -197,51 +229,46 @@ def init_fsl_hmc_wf(scan_groups,
                 ('t1_brain', 'inputnode.t1_brain'),
                 ('t1_2_mni_reverse_transform',
                  'inputnode.t1_2_mni_reverse_transform')]),
+            # These deformations will be applied later, use the unwarped image now. Nilearn
+            # uses physical coordinates for plotting
+            (b0_sdc_wf, outputnode, [
+                ('outputnode.method', 'sdc_method')]),
+            # Send the fieldmap (Hz) to eddy
+            (b0_sdc_wf, eddy, [('outputnode.fieldmap_hz', 'field')])])
+    else:
+        outputnode.inputs.sdc_method = "None"
+
+    mean_b0_lps = pe.Node(ants.AverageImages(dimension=3, normalize=True), name='mean_b0_lps')
+    lps_b0_enhance = init_enhance_and_skullstrip_dwi_wf(name='lps_b0_enhance')
+
+    if fieldmap_type == 'syn':
+        outputnode.inputs.sdc_method = fieldmap_type
+        b0_sdc_wf = init_sdc_wf(
+            scan_groups['fieldmap_info'], dwi_metadata, omp_nthreads=omp_nthreads,
+            fmap_demean=fmap_demean, fmap_bspline=fmap_bspline)
+
+        workflow.connect([
+            (lps_b0_enhance, b0_sdc_wf, [
+                ('outputnode.bias_corrected_file', 'inputnode.b0_ref'),
+                ('outputnode.skull_stripped_file', 'inputnode.b0_ref_brain'),
+                ('outputnode.mask_file', 'inputnode.b0_mask')]),
+            (inputnode, b0_sdc_wf, [
+                ('t1_brain', 'inputnode.t1_brain'),
+                ('t1_2_mni_reverse_transform',
+                 'inputnode.t1_2_mni_reverse_transform')]),
+            # These deformations will be applied later, use the unwarped image now
             (b0_sdc_wf, outputnode, [
                 ('outputnode.method', 'sdc_method'),
                 ('outputnode.b0_ref', 'b0_template'),
-                ('outputnode.b0_mask', 'b0_template_mask')]),
-            (b0_sdc_wf, eddy, [
-                ('outputnode.b0_mask', 'in_mask')])])
-        if fieldmap_type == 'syn':
-            # SyN has transforms passed to the outputnode
-            workflow.connect([
-                (b0_sdc_wf, outputnode, [
-                    ('outputnode.out_warp', 'to_dwi_ref_warps')])])
-        else:
-            # Phasediff, phase, fieldmap can be passed to eddy
-            workflow.connect([
-                (b0_sdc_wf, eddy, [('outputnode.fieldmap_hz', 'field')])])
-    else:
-        outputnode.inputs.sdc_method = "None"
-        b0_enhance = init_enhance_and_skullstrip_dwi_wf(name='b0_enhance')
-        workflow.connect([
-            (gather_inputs, b0_enhance, [('pre_topup_image', 'inputnode.in_file')]),
-            (b0_enhance, outputnode, [
-                ('outputnode.skull_stripped_file', 'b0_template')]),
-            (b0_enhance, outputnode, [
-                ('outputnode.mask_file', 'b0_template_mask')]),
-            (b0_enhance, eddy, [
-                ('outputnode.mask_file', 'in_mask')])])
+                ('outputnode.b0_mask', 'b0_template_mask')])])
 
-    # Organize outputs for the rest of the pipeline
-    split_eddy = pe.Node(SplitDWIs(b0_threshold=b0_threshold), name="split_eddy")
-    workflow.connect([
-        (eddy, split_eddy, [
-            ('out_rotated_bvecs', 'bvec_file'),
-            ('out_corrected', 'dwi_file')]),
-        (dwi_merge, split_eddy, [('out_bval', 'bval_file')]),
-        (dwi_merge, outputnode, [
-            ('original_images', 'original_files')]),
-        (split_eddy, outputnode, [
-            ('dwi_files', 'dwi_files_to_transform'),
-            ('bvec_files', 'bvec_files_to_transform')]),
-        (eddy, outputnode, [
-            (slice_quality, 'slice_quality'),
-            ('out_cnr_maps', 'cnr_map'),
-            (slice_quality, 'hmc_optimization_data')]),
-        (eddy, spm_motion, [('out_parameter', 'eddy_motion')]),
-        (spm_motion, outputnode, [('spm_motion_file', 'motion_params')])
-    ])
+    else:
+        workflow.connect([
+            (split_eddy_lps, mean_b0_lps, [('b0_images', 'images')]),
+            (mean_b0_lps, lps_b0_enhance, [('output_average_image', 'inputnode.in_file')]),
+            (lps_b0_enhance, outputnode, [
+                ('outputnode.skull_stripped_file', 'b0_template'),
+                ('outputnode.mask_file', 'b0_template_mask')]),
+            ])
 
     return workflow

--- a/qsiprep/workflows/dwi/fsl.py
+++ b/qsiprep/workflows/dwi/fsl.py
@@ -6,23 +6,18 @@ Orchestrating the dwi-preprocessing workflow
 
 """
 
-import os
 import json
 from pkg_resources import resource_filename as pkgr_fn
-
-import nibabel as nb
 from nipype import logging
 
 from nipype.pipeline import engine as pe
 from nipype.interfaces import utility as niu
 from nipype.interfaces import fsl, afni, ants
 
-from ...interfaces import DerivativesDataSink
 from ...interfaces.eddy import GatherEddyInputs, ExtendedEddy, Eddy2SPMMotion
 from ...interfaces.dwi_merge import MergeDWIs
 from ...interfaces.images import SplitDWIs, ConformDwi
 from ...interfaces.fmap import B0RPEFieldmap
-from ...interfaces.gradients import ExtractB0s
 from ...engine import Workflow
 
 # dwi workflows

--- a/qsiprep/workflows/dwi/hmc.py
+++ b/qsiprep/workflows/dwi/hmc.py
@@ -169,7 +169,7 @@ def linear_alignment_workflow(transform="Rigid", metric="Mattes", iternum=0, pre
     Returns a workflow
 
     """
-    iteration_wf = pe.Workflow(name="iterative_alignment_%03d" % iternum)
+    iteration_wf = Workflow(name="iterative_alignment_%03d" % iternum)
     input_node_fields = ["image_paths", "template_image", "iteration_num"]
     inputnode = pe.Node(
         niu.IdentityInterface(fields=input_node_fields), name='inputnode')
@@ -232,7 +232,7 @@ def init_b0_hmc_wf(align_to="iterative", transform="Rigid", spatial_bias_correct
     if align_to == "iterative" and num_iters < 2:
         raise ValueError("Must specify a positive number of iterations")
 
-    alignment_wf = pe.Workflow(name=name)
+    alignment_wf = Workflow(name=name)
     inputnode = pe.Node(
         niu.IdentityInterface(fields=['b0_images']), name='inputnode')
     outputnode = pe.Node(

--- a/qsiprep/workflows/dwi/merge.py
+++ b/qsiprep/workflows/dwi/merge.py
@@ -19,7 +19,7 @@ from nipype import logging
 from nipype.pipeline import engine as pe
 from nipype.interfaces import utility as niu
 
-from ...interfaces import MergeDWIs, ConformDwi
+from ...interfaces import MergeDWIs, ConformDwi, ValidateImage
 from ...interfaces.mrtrix import DWIDenoise
 
 from ...engine import Workflow
@@ -30,6 +30,7 @@ LOGGER = logging.getLogger('nipype.workflow')
 
 def init_merge_and_denoise_wf(dwi_denoise_window,
                               denoise_before_combining,
+                              orientation,
                               mem_gb=1,
                               omp_nthreads=1,
                               name="merge_and_denoise_wf"):
@@ -85,7 +86,9 @@ def init_merge_and_denoise_wf(dwi_denoise_window,
             'merged_image', 'merged_bval', 'merged_bvec', 'noise_image', 'original_files']),
         name='outputnode')
 
-    conform_dwis = pe.MapNode(ConformDwi(), iterfield=['dwi_file'], name="conform_dwis")
+    # validate_dwis = pe.MapNode(ValidateImage(), iterfield=[], name='validate_dwis')
+    conform_dwis = pe.MapNode(
+        ConformDwi(orientation=orientation), iterfield=['dwi_file'], name="conform_dwis")
     merge_dwis = pe.Node(MergeDWIs(), name='merge_dwis')
 
     workflow.connect([

--- a/qsiprep/workflows/dwi/util.py
+++ b/qsiprep/workflows/dwi/util.py
@@ -11,13 +11,9 @@ Utility workflows
 """
 import os
 import nibabel as nb
-from packaging.version import parse as parseversion, Version
-from pkg_resources import resource_filename as pkgr_fn
 
 from nipype.pipeline import engine as pe
 from nipype.interfaces import utility as niu, fsl, afni, ants
-from ...niworkflows.data import get_template
-from ...niworkflows.interfaces.ants import AI
 from ...niworkflows.interfaces import SimpleBeforeAfter
 from ...niworkflows.interfaces.fixes import (
     FixHeaderRegistration as Registration,

--- a/qsiprep/workflows/fieldmap/base.py
+++ b/qsiprep/workflows/fieldmap/base.py
@@ -41,7 +41,6 @@ from nipype.interfaces import utility as niu
 from nipype import logging
 
 from ...engine import Workflow
-from ...interfaces.fmap import B0RPEFieldmap
 
 # Fieldmap workflows
 from .pepolar import init_pepolar_unwarp_wf

--- a/qsiprep/workflows/fieldmap/pepolar.py
+++ b/qsiprep/workflows/fieldmap/pepolar.py
@@ -232,7 +232,7 @@ def init_prepare_epi_wf(omp_nthreads, name="prepare_epi_wf"):
 
     return workflow
 
-def init_prepare_dwi_epi_wf(omp_nthreads, name="prepare_epi_wf"):
+def init_prepare_dwi_epi_wf(omp_nthreads, orientation="LPS", name="prepare_epi_wf"):
     """
     This workflow takes in a set of dwi files with with the same phase
     encoding direction and returns a single 3D volume ready to be used in
@@ -249,8 +249,9 @@ def init_prepare_dwi_epi_wf(omp_nthreads, name="prepare_epi_wf"):
     outputnode = pe.Node(niu.IdentityInterface(fields=['out_file']),
                          name='outputnode')
 
-    prepare_b0s = pe.MapNode(B0RPEFieldmap(output_3d_images=True), iterfield='b0_file',
-                             name='prepare_b0s')
+    prepare_b0s = pe.MapNode(
+        B0RPEFieldmap(output_3d_images=True, orientation=orientation),
+        iterfield='b0_file', name='prepare_b0s')
 
     merge = pe.Node(
         StructuralReference(auto_detect_sensitivity=True,

--- a/qsiprep/workflows/fieldmap/unwarp.py
+++ b/qsiprep/workflows/fieldmap/unwarp.py
@@ -244,6 +244,7 @@ def init_fmap_unwarp_report_wf(name='fmap_unwarp_report_wf', suffix='hmcsdc'):
     """
     from ...niworkflows.interfaces import SimpleBeforeAfter
     from ...niworkflows.interfaces.images import extract_wm
+    from ...niworkflows.interfaces.fixes import FixHeaderApplyTransforms as ApplyTransforms
 
     DEFAULT_MEMORY_MIN_GB = 0.01
 
@@ -253,7 +254,7 @@ def init_fmap_unwarp_report_wf(name='fmap_unwarp_report_wf', suffix='hmcsdc'):
         fields=['in_pre', 'in_post', 'in_seg', 'in_xfm']), name='inputnode')
 
     map_seg = pe.Node(
-        ants.ApplyTransforms(dimension=3, float=True, interpolation='MultiLabel',
+            ApplyTransforms(dimension=3, float=True, interpolation='MultiLabel',
                              invert_transform_flags=[True]),
         name='map_seg',
         mem_gb=0.3)

--- a/qsiprep/workflows/recon/base.py
+++ b/qsiprep/workflows/recon/base.py
@@ -18,7 +18,6 @@ from glob import glob
 from copy import deepcopy
 from pkg_resources import resource_filename as pkgrf
 from nipype import __version__ as nipype_ver
-from nipype.pipeline import engine as pe
 from nipype.interfaces import utility as niu
 from nipype.utils.filemanip import split_filename
 from ...engine import Workflow
@@ -171,7 +170,7 @@ def init_single_subject_wf(
                      if 'space-' + space in f.filename]
         LOGGER.info("found %s in %s", dwi_files, recon_input)
 
-    workflow = pe.Workflow('sub-{}_{}'.format(subject_id, spec['name']))
+    workflow = Workflow('sub-{}_{}'.format(subject_id, spec['name']))
     if len(dwi_files) == 0:
         LOGGER.info("No dwi files found for %s", subject_id)
         return workflow

--- a/qsiprep/workflows/recon/converters.py
+++ b/qsiprep/workflows/recon/converters.py
@@ -25,6 +25,7 @@ from pkg_resources import resource_filename as pkgr
 from qsiprep.interfaces.converters import FODtoFIBGZ
 from qsiprep.interfaces.bids import ReconDerivativesDataSink
 from .interchange import input_fields, default_connections
+from ...engine import Workflow
 LOGGER = logging.getLogger('nipype.workflow')
 
 
@@ -50,7 +51,7 @@ def init_mif_to_fibgz_wf(name="mif_to_fibgz", output_suffix="", params={}):
                         name="inputnode")
     outputnode = pe.Node(
         niu.IdentityInterface(fields=['fib_file']), name="outputnode")
-    workflow = pe.Workflow(name=name)
+    workflow = Workflow(name=name)
     convert_to_fib = pe.Node(FODtoFIBGZ(), name="convert_to_fib")
     workflow.connect([
         (inputnode, convert_to_fib, [('mif_file', 'mif_file')]),
@@ -65,7 +66,7 @@ def init_fibgz_to_mif_wf(name="fibgz_to_mif", output_suffix="", params={}):
                         name="inputnode")
     outputnode = pe.Node(
         niu.IdentityInterface(fields=['fib_file']), name="outputnode")
-    workflow = pe.Workflow(name=name)
+    workflow = Workflow(name=name)
     convert_to_fib = pe.Node(FODtoFIBGZ(), name="convert_to_fib")
     workflow.connect([
         (inputnode, convert_to_fib, [('mif_file', 'mif_file')]),

--- a/qsiprep/workflows/recon/dipy.py
+++ b/qsiprep/workflows/recon/dipy.py
@@ -16,6 +16,7 @@ import os.path as op
 from qsiprep.interfaces.bids import ReconDerivativesDataSink
 from ...interfaces.dipy import BrainSuiteShoreReconstruction, MAPMRIReconstruction
 from .interchange import input_fields
+from ...engine import Workflow
 
 LOGGER = logging.getLogger('nipype.interface')
 
@@ -105,7 +106,7 @@ def init_dipy_brainsuite_shore_recon_wf(name="dipy_3dshore_recon", output_suffix
                     'dwi_file', 'bval_file', 'bvec_file', 'b_file']),
         name="outputnode")
 
-    workflow = pe.Workflow(name=name)
+    workflow = Workflow(name=name)
     resample_mask = pe.Node(
         afni.Resample(outputtype='NIFTI_GZ', resample_mode="NN"), name='resample_mask')
     recon_shore = pe.Node(BrainSuiteShoreReconstruction(**params), name="recon_shore")
@@ -303,7 +304,7 @@ def init_dipy_mapmri_recon_wf(name="dipy_mapmri_recon", output_suffix="", params
                     'parng', 'perng', 'ng', 'qiv', 'lapnorm', 'msd']),
         name="outputnode")
 
-    workflow = pe.Workflow(name=name)
+    workflow = Workflow(name=name)
     recon_map = pe.Node(MAPMRIReconstruction(**params), name="recon_map")
     resample_mask = pe.Node(
         afni.Resample(outputtype='NIFTI_GZ', resample_mode="NN"), name='resample_mask')


### PR DESCRIPTION
Fieldmaps weren't being handled correctly in eddy, either from the sdc workflows (phasediff, phases) or from TOPUP. Topup only worked correctly with eddy if everything was in LAS+, so now that is the default for that workflow. Everything is converted back to LPS+ after eddy and sdc workflows happen to the eddy-corrected data. Closes #35.
