### PR TITLE
[ENH] Use BSpline interpolation when outputs have smaller voxels

### DIFF
--- a/docs/preprocessing.rst
+++ b/docs/preprocessing.rst
@@ -505,6 +505,7 @@ Pre-processed DWIs in a different space
 
     from qsiprep.workflows.dwi.resampling import init_dwi_trans_wf
     wf = init_dwi_trans_wf(template="ACPC",
+                           output_resolution=1.2,
                            use_fieldwarp=True,
                            use_compression=True,
                            to_mni=False,

--- a/qsiprep/cli/run.py
+++ b/qsiprep/cli/run.py
@@ -225,7 +225,7 @@ def get_parser():
         type=float,
         help='the isotropic voxel size in mm the data will be resampled to '
         'after preprocessing. If set to a lower value than the original voxel '
-        'size, your data will be upsampled. This is a required argument.')
+        'size, your data will be upsampled using BSpline interpolation.')
 
     g_coreg = parser.add_argument_group('Options for dwi-to-T1w coregistration')
     g_coreg.add_argument(

--- a/qsiprep/interfaces/images.py
+++ b/qsiprep/interfaces/images.py
@@ -443,15 +443,17 @@ class ChooseInterpolator(SimpleInterface):
     output_spec = _ChooseInterpolatorOutputSpec
 
     def _run_interface(self, runtime):
-        output_resolution = np.array([self.inputs.output_resolution] * 3) * 0.9
+        output_resolution = np.array([self.inputs.output_resolution] * 3)
         interpolator = "LanczosWindowedSinc"
         for input_file in self.inputs.dwi_files:
-            original_resolution = np.load(input_file).header.get_zooms()[:3]
-            if np.any(output_resolution < original_resolution):
+            resolution_cutoff = 0.9 * np.array(nb.load(input_file).header.get_zooms()[:3])
+            print(output_resolution, resolution_cutoff)
+            if np.any(output_resolution < resolution_cutoff):
                 interpolator = "BSpline"
                 LOGGER.warning("Using BSpline interpolation for upsampling")
                 break
         self._results['interpolation_method'] = interpolator
+        return runtime
 
 
 class ValidateImageOutputSpec(TraitedSpec):

--- a/qsiprep/interfaces/images.py
+++ b/qsiprep/interfaces/images.py
@@ -327,7 +327,8 @@ class Conform(SimpleInterface):
             out_name = fname_presuffix(fname, suffix='_lps', newpath=runtime.cwd)
             reoriented.to_filename(out_name)
             transform = ornt_xfm.dot(conform_xfm)
-            assert np.allclose(orig_img.affine.dot(transform), target_affine)
+            if not np.allclose(orig_img.affine.dot(transform), target_affine):
+                LOGGER.warning("Check alignment of anatomical image.")
 
         else:
             out_name = fname

--- a/qsiprep/workflows/base.py
+++ b/qsiprep/workflows/base.py
@@ -635,6 +635,7 @@ to workflows in *qsiprep*'s documentation]\
             reportlets_dir=reportlets_dir,
             output_spaces=output_spaces,
             template=template,
+            output_resolution=output_resolution,
             output_dir=output_dir,
             omp_nthreads=omp_nthreads,
             use_syn=use_syn,

--- a/qsiprep/workflows/dwi/finalize.py
+++ b/qsiprep/workflows/dwi/finalize.py
@@ -36,6 +36,7 @@ def init_dwi_finalize_wf(scan_groups,
                          shoreline_iters,
                          reportlets_dir,
                          output_spaces,
+                         output_resolution,
                          template,
                          output_dir,
                          omp_nthreads,
@@ -51,12 +52,13 @@ def init_dwi_finalize_wf(scan_groups,
         :graph2use: orig
         :simple_form: yes
 
-        from qsiprep.workflows.dwi.base import init_dwi_finalize_wf(scan_groups, name, output_prefix, ignore, hmc_model, shoreline_iters, reportlets_dir, output_spaces, template, output_dir, omp_nthreads, write_local_bvecs, low_mem, use_syn, make_intramodal_template, layout)
+        from qsiprep.workflows.dwi.base import init_dwi_finalize_wf
         wf = init_dwi_finalize_wf(name='finalize_wf',
                                   omp_nthreads=1,
                                   ignore=[],
                                   reportlets_dir='.',
                                   output_dir='.',
+                                  output_resolution=2.0,
                                   template='MNI152NLin2009cAsym',
                                   output_spaces=['T1w', 'template'],
                                   low_mem=False,
@@ -86,6 +88,8 @@ def init_dwi_finalize_wf(scan_groups,
             Name of template targeted by ``template`` output space
         output_dir : str
             Directory in which to save derivatives
+        output_resolution : float
+            Output voxel resolution in mm
         omp_nthreads : int
             Maximum number of threads an individual process may use
         low_mem : bool
@@ -294,6 +298,7 @@ def init_dwi_finalize_wf(scan_groups,
                                               use_fieldwarp=(fieldmap_type is not None
                                                              or use_syn),
                                               omp_nthreads=omp_nthreads,
+                                              output_resolution=output_resolution,
                                               use_compression=False,
                                               to_mni=False,
                                               write_local_bvecs=write_local_bvecs)
@@ -338,6 +343,7 @@ def init_dwi_finalize_wf(scan_groups,
                                                use_fieldwarp=(fieldmap_type is not None
                                                               or use_syn),
                                                omp_nthreads=omp_nthreads,
+                                               output_resolution=output_resolution,
                                                use_compression=False,
                                                to_mni=True,
                                                write_local_bvecs=write_local_bvecs)

--- a/qsiprep/workflows/dwi/resampling.py
+++ b/qsiprep/workflows/dwi/resampling.py
@@ -43,6 +43,7 @@ def init_dwi_trans_wf(template,
 
         from qsiprep.workflows.dwi.resampling import init_dwi_trans_wf
         wf = init_dwi_trans_wf(template='MNI152NLin2009cAsym',
+                               output_resolution=1.2,
                                mem_gb=3,
                                omp_nthreads=1)
 


### PR DESCRIPTION

## Changes proposed in this pull request

 * Use BSpline interpolation if `--output-resolution` has a smaller voxel size than the inputs

<!--
Please describe here the main features / changes proposed for review and integration in qsiprep
If this PR addresses some existing problem, please use GitHub's citing tools 
(eg. ref #, closes # or fixes #).
If there is not an existing issue open describing the problem, please consider opening a new
issue first and then link it from here (so the *qsiprep* community has a better understanding
of ongoing development efforts and possible overlaps between contributions).
-->