### PR TITLE
FIX: only run bids if not recon-only *and* not skip bids

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -14,6 +14,11 @@
       "name": "He, Xiaosong",
       "affiliation": "Department of Bioengineering, University of Pennsylvania",
       "orcid": "0000-0002-7941-2918"
+    },
+    {
+      "name": "Foran, William",
+      "affiliation": "Department of Psychiatry, University of Pittsburgh Medical Center",
+      "orcid": "0000-0001-7491-9798"
     }
   ],
   "keywords": [

--- a/qsiprep/cli/run.py
+++ b/qsiprep/cli/run.py
@@ -445,7 +445,7 @@ def main():
             if os.getenv('DOCKER_VERSION_8395080871'):
                 exec_env = 'qsiprep-docker'
     # Validate inputs
-    if not opts.recon_only or not opts.skip_bids_validation:
+    if not opts.recon_only and not opts.skip_bids_validation:
         print("Making sure the input data is BIDS compliant (warnings can be ignored in most "
               "cases).")
         validate_input_dir(exec_env, opts.bids_dir, opts.participant_label)


### PR DESCRIPTION
## Changes proposed in this pull request
Skip BIDS validation when either `--skip-bids-validation` or `--recon-only` are supplied. 
Previously, both were need both to skip validation.

## Documentation that should be reviewed
N/A unless previous behavior is intended, then maybe a note in `--skip_bids_validation`'s parser help text