### PR TITLE
[ENH] Prevent too many images from being used by topup

### DIFF
--- a/qsiprep/interfaces/dsi_studio.py
+++ b/qsiprep/interfaces/dsi_studio.py
@@ -557,5 +557,4 @@ class FixDSIStudioExportHeader(SimpleInterface):
         else:
             self._results['out_file'] = dsi_studio_file
 
-
         return runtime

--- a/wrapper/qsiprep_docker.py
+++ b/wrapper/qsiprep_docker.py
@@ -264,6 +264,8 @@ def get_parser():
                         required=False,
                         action='store',
                         type=str)
+    g_wrap.add_argument('--gpus', required=False,
+                        help='gpus argument sent to docker', type=str)
 
     # Developer patch/shell options
     g_dev = parser.add_argument_group(
@@ -378,6 +380,8 @@ def main():
     if opts.recon_input:
         command.extend(['-v', ':'.join((opts.recon_input, '/qsiprep-output', 'ro'))])
         main_args.extend(['--recon-input', '/qsiprep-output'])
+    if opts.gpus:
+        command.extend(['--gpus', opts.gpus])
     if opts.recon_spec:
         if os.path.exists(opts.recon_spec):
             command.extend(['-v', ':'.join((opts.recon_spec, '/sngl/spec/spec.json', 'ro'))])


### PR DESCRIPTION
Currently there can be up to 12 images sent to topup if there were two dwi series with opposite phase encoding directions and two opposite epi fieldmaps. This PR forces only up to 6 images to be used: 3 per phase encoding direction. DWI b=0s are preferred over epi fieldmap b=0's.