### PR TITLE
[ENH] Make dwi masking more robust

### DIFF
--- a/.circleci/DSCSDSI_outputs.txt
+++ b/.circleci/DSCSDSI_outputs.txt
@@ -24,7 +24,6 @@ qsiprep/sub-tester/anat/sub-tester_space-MNI152NLin2009cAsym_label-WM_probseg.ni
 qsiprep/sub-tester/dwi
 qsiprep/sub-tester/dwi/sub-tester_acq-HASC55AP_confounds.tsv
 qsiprep/sub-tester/dwi/sub-tester_acq-HASC55AP_desc-ImageQC_dwi.csv
-qsiprep/sub-tester/dwi/sub-tester_acq-HASC55AP_space-T1w_b0series.nii.gz
 qsiprep/sub-tester/dwi/sub-tester_acq-HASC55AP_space-T1w_desc-3dSHORE_cnr.nii.gz
 qsiprep/sub-tester/dwi/sub-tester_acq-HASC55AP_space-T1w_desc-brain_mask.nii.gz
 qsiprep/sub-tester/dwi/sub-tester_acq-HASC55AP_space-T1w_desc-preproc_dwi.b

--- a/.circleci/DSCSDSI_outputs.txt
+++ b/.circleci/DSCSDSI_outputs.txt
@@ -34,7 +34,7 @@ qsiprep/sub-tester/dwi/sub-tester_acq-HASC55AP_space-T1w_dwiref.nii.gz
 qsiprep/sub-tester/figures
 qsiprep/sub-tester/figures/sub-tester_acq-HASC55AP_carpetplot.svg
 qsiprep/sub-tester/figures/sub-tester_acq-HASC55AP_coreg.svg
-qsiprep/sub-tester/figures/sub-tester_acq-HASC55AP_desc-initial_b0ref.svg
+qsiprep/sub-tester/figures/sub-tester_acq-HASC55AP_desc-resampled_b0ref.svg
 qsiprep/sub-tester/figures/sub-tester_acq-HASC55AP_desc-sdc_b0.svg
 qsiprep/sub-tester/figures/sub-tester_acq-HASC55AP_merged_denoise_denoising.svg
 qsiprep/sub-tester/figures/sub-tester_acq-HASC55AP_sampling_scheme.gif

--- a/.circleci/DSDTI_nofmap_outputs.txt
+++ b/.circleci/DSDTI_nofmap_outputs.txt
@@ -24,7 +24,6 @@ qsiprep/sub-PNC/anat/sub-PNC_space-MNI152NLin2009cAsym_label-WM_probseg.nii.gz
 qsiprep/sub-PNC/dwi
 qsiprep/sub-PNC/dwi/sub-PNC_acq-realistic_confounds.tsv
 qsiprep/sub-PNC/dwi/sub-PNC_acq-realistic_desc-ImageQC_dwi.csv
-qsiprep/sub-PNC/dwi/sub-PNC_acq-realistic_space-T1w_b0series.nii.gz
 qsiprep/sub-PNC/dwi/sub-PNC_acq-realistic_space-T1w_desc-brain_mask.nii.gz
 qsiprep/sub-PNC/dwi/sub-PNC_acq-realistic_space-T1w_desc-eddy_cnr.nii.gz
 qsiprep/sub-PNC/dwi/sub-PNC_acq-realistic_space-T1w_desc-preproc_dwi.b

--- a/.circleci/DSDTI_nofmap_outputs.txt
+++ b/.circleci/DSDTI_nofmap_outputs.txt
@@ -32,9 +32,9 @@ qsiprep/sub-PNC/dwi/sub-PNC_acq-realistic_space-T1w_desc-preproc_dwi.bvec
 qsiprep/sub-PNC/dwi/sub-PNC_acq-realistic_space-T1w_desc-preproc_dwi.nii.gz
 qsiprep/sub-PNC/dwi/sub-PNC_acq-realistic_space-T1w_dwiref.nii.gz
 qsiprep/sub-PNC/figures
-qsiprep/sub-PNC/figures/sub-PNC_acq-realistic_desc-resampled_b0ref.svg
 qsiprep/sub-PNC/figures/sub-PNC_acq-realistic_carpetplot.svg
 qsiprep/sub-PNC/figures/sub-PNC_acq-realistic_coreg.svg
+qsiprep/sub-PNC/figures/sub-PNC_acq-realistic_desc-resampled_b0ref.svg
 qsiprep/sub-PNC/figures/sub-PNC_acq-realistic_desc-sdc_b0.svg
 qsiprep/sub-PNC/figures/sub-PNC_acq-realistic_merged_denoise_biascorr.svg
 qsiprep/sub-PNC/figures/sub-PNC_acq-realistic_merged_denoise_denoising.svg

--- a/.circleci/DSDTI_nofmap_outputs.txt
+++ b/.circleci/DSDTI_nofmap_outputs.txt
@@ -32,6 +32,7 @@ qsiprep/sub-PNC/dwi/sub-PNC_acq-realistic_space-T1w_desc-preproc_dwi.bvec
 qsiprep/sub-PNC/dwi/sub-PNC_acq-realistic_space-T1w_desc-preproc_dwi.nii.gz
 qsiprep/sub-PNC/dwi/sub-PNC_acq-realistic_space-T1w_dwiref.nii.gz
 qsiprep/sub-PNC/figures
+qsiprep/sub-PNC/figures/sub-PNC_acq-realistic_desc-resampled_b0ref.svg
 qsiprep/sub-PNC/figures/sub-PNC_acq-realistic_carpetplot.svg
 qsiprep/sub-PNC/figures/sub-PNC_acq-realistic_coreg.svg
 qsiprep/sub-PNC/figures/sub-PNC_acq-realistic_desc-sdc_b0.svg

--- a/.circleci/DSDTI_outputs.txt
+++ b/.circleci/DSDTI_outputs.txt
@@ -34,6 +34,7 @@ qsiprep/sub-PNC/dwi/sub-PNC_acq-realistic_space-T1w_dwiref.nii.gz
 qsiprep/sub-PNC/figures
 qsiprep/sub-PNC/figures/sub-PNC_acq-realistic_carpetplot.svg
 qsiprep/sub-PNC/figures/sub-PNC_acq-realistic_coreg.svg
+qsiprep/sub-PNC/figures/sub-PNC_acq-realistic_desc-resampled_b0ref.svg
 qsiprep/sub-PNC/figures/sub-PNC_acq-realistic_desc-sdc_b0.svg
 qsiprep/sub-PNC/figures/sub-PNC_acq-realistic_merged_denoise_biascorr.svg
 qsiprep/sub-PNC/figures/sub-PNC_acq-realistic_merged_denoise_denoising.svg

--- a/.circleci/DSDTI_outputs.txt
+++ b/.circleci/DSDTI_outputs.txt
@@ -24,7 +24,6 @@ qsiprep/sub-PNC/anat/sub-PNC_space-MNI152NLin2009cAsym_label-WM_probseg.nii.gz
 qsiprep/sub-PNC/dwi
 qsiprep/sub-PNC/dwi/sub-PNC_acq-realistic_confounds.tsv
 qsiprep/sub-PNC/dwi/sub-PNC_acq-realistic_desc-ImageQC_dwi.csv
-qsiprep/sub-PNC/dwi/sub-PNC_acq-realistic_space-T1w_b0series.nii.gz
 qsiprep/sub-PNC/dwi/sub-PNC_acq-realistic_space-T1w_desc-brain_mask.nii.gz
 qsiprep/sub-PNC/dwi/sub-PNC_acq-realistic_space-T1w_desc-eddy_cnr.nii.gz
 qsiprep/sub-PNC/dwi/sub-PNC_acq-realistic_space-T1w_desc-preproc_dwi.b

--- a/.circleci/DSDTI_synsdc_outputs.txt
+++ b/.circleci/DSDTI_synsdc_outputs.txt
@@ -34,6 +34,7 @@ qsiprep/sub-PNC/dwi/sub-PNC_acq-realistic_space-T1w_dwiref.nii.gz
 qsiprep/sub-PNC/figures
 qsiprep/sub-PNC/figures/sub-PNC_acq-realistic_carpetplot.svg
 qsiprep/sub-PNC/figures/sub-PNC_acq-realistic_coreg.svg
+qsiprep/sub-PNC/figures/sub-PNC_acq-realistic_desc-resampled_b0ref.svg
 qsiprep/sub-PNC/figures/sub-PNC_acq-realistic_desc-sdc_b0.svg
 qsiprep/sub-PNC/figures/sub-PNC_acq-realistic_merged_denoise_biascorr.svg
 qsiprep/sub-PNC/figures/sub-PNC_acq-realistic_merged_denoise_denoising.svg

--- a/.circleci/DSDTI_synsdc_outputs.txt
+++ b/.circleci/DSDTI_synsdc_outputs.txt
@@ -24,7 +24,6 @@ qsiprep/sub-PNC/anat/sub-PNC_space-MNI152NLin2009cAsym_label-WM_probseg.nii.gz
 qsiprep/sub-PNC/dwi
 qsiprep/sub-PNC/dwi/sub-PNC_acq-realistic_confounds.tsv
 qsiprep/sub-PNC/dwi/sub-PNC_acq-realistic_desc-ImageQC_dwi.csv
-qsiprep/sub-PNC/dwi/sub-PNC_acq-realistic_space-T1w_b0series.nii.gz
 qsiprep/sub-PNC/dwi/sub-PNC_acq-realistic_space-T1w_desc-brain_mask.nii.gz
 qsiprep/sub-PNC/dwi/sub-PNC_acq-realistic_space-T1w_desc-eddy_cnr.nii.gz
 qsiprep/sub-PNC/dwi/sub-PNC_acq-realistic_space-T1w_desc-preproc_dwi.b

--- a/.circleci/IntramodalTemplate_outputs.txt
+++ b/.circleci/IntramodalTemplate_outputs.txt
@@ -17,13 +17,13 @@ qsiprep/sub-tester/figures/sub-tester_imtcoreg.svg
 qsiprep/sub-tester/figures/sub-tester_seg_brainmask.svg
 qsiprep/sub-tester/figures/sub-tester_ses-1_acq-HASC55PA_carpetplot.svg
 qsiprep/sub-tester/figures/sub-tester_ses-1_acq-HASC55PA_coreg.svg
-qsiprep/sub-tester/figures/sub-tester_ses-1_acq-HASC55PA_desc-initial_b0ref.svg
+qsiprep/sub-tester/figures/sub-tester_ses-1_acq-HASC55PA_desc-resampled_b0ref.svg
 qsiprep/sub-tester/figures/sub-tester_ses-1_acq-HASC55PA_merged_denoise_biascorr.svg
 qsiprep/sub-tester/figures/sub-tester_ses-1_acq-HASC55PA_sampling_scheme.gif
 qsiprep/sub-tester/figures/sub-tester_ses-1_acq-HASC55PA_tointramodal.svg
 qsiprep/sub-tester/figures/sub-tester_ses-2_acq-HASC55AP_carpetplot.svg
 qsiprep/sub-tester/figures/sub-tester_ses-2_acq-HASC55AP_coreg.svg
-qsiprep/sub-tester/figures/sub-tester_ses-2_acq-HASC55AP_desc-initial_b0ref.svg
+qsiprep/sub-tester/figures/sub-tester_ses-2_acq-HASC55AP_desc-resampled_b0ref.svg
 qsiprep/sub-tester/figures/sub-tester_ses-2_acq-HASC55AP_merged_denoise_biascorr.svg
 qsiprep/sub-tester/figures/sub-tester_ses-2_acq-HASC55AP_sampling_scheme.gif
 qsiprep/sub-tester/figures/sub-tester_ses-2_acq-HASC55AP_tointramodal.svg

--- a/.circleci/IntramodalTemplate_outputs.txt
+++ b/.circleci/IntramodalTemplate_outputs.txt
@@ -34,7 +34,6 @@ qsiprep/sub-tester/ses-1/anat/sub-tester_ses-1_from-orig_to-T1w_mode-image_xfm.t
 qsiprep/sub-tester/ses-1/dwi
 qsiprep/sub-tester/ses-1/dwi/sub-tester_ses-1_acq-HASC55PA_confounds.tsv
 qsiprep/sub-tester/ses-1/dwi/sub-tester_ses-1_acq-HASC55PA_desc-ImageQC_dwi.csv
-qsiprep/sub-tester/ses-1/dwi/sub-tester_ses-1_acq-HASC55PA_space-T1w_b0series.nii.gz
 qsiprep/sub-tester/ses-1/dwi/sub-tester_ses-1_acq-HASC55PA_space-T1w_desc-brain_mask.nii.gz
 qsiprep/sub-tester/ses-1/dwi/sub-tester_ses-1_acq-HASC55PA_space-T1w_desc-none_cnr.nii.gz
 qsiprep/sub-tester/ses-1/dwi/sub-tester_ses-1_acq-HASC55PA_space-T1w_desc-preproc_dwi.b
@@ -46,7 +45,6 @@ qsiprep/sub-tester/ses-2
 qsiprep/sub-tester/ses-2/dwi
 qsiprep/sub-tester/ses-2/dwi/sub-tester_ses-2_acq-HASC55AP_confounds.tsv
 qsiprep/sub-tester/ses-2/dwi/sub-tester_ses-2_acq-HASC55AP_desc-ImageQC_dwi.csv
-qsiprep/sub-tester/ses-2/dwi/sub-tester_ses-2_acq-HASC55AP_space-T1w_b0series.nii.gz
 qsiprep/sub-tester/ses-2/dwi/sub-tester_ses-2_acq-HASC55AP_space-T1w_desc-brain_mask.nii.gz
 qsiprep/sub-tester/ses-2/dwi/sub-tester_ses-2_acq-HASC55AP_space-T1w_desc-none_cnr.nii.gz
 qsiprep/sub-tester/ses-2/dwi/sub-tester_ses-2_acq-HASC55AP_space-T1w_desc-preproc_dwi.b

--- a/docs/preprocessing.rst
+++ b/docs/preprocessing.rst
@@ -532,9 +532,9 @@ Pre-processed DWIs in a different space
     :simple_form: yes
 
     from qsiprep.workflows.dwi.resampling import init_dwi_trans_wf
-    wf = init_dwi_trans_wf(template="ACPC",
+    wf = init_dwi_trans_wf(source_file='sub-1_dwi.nii.gz',
+                           template="ACPC",
                            output_resolution=1.2,
-                           use_fieldwarp=True,
                            use_compression=True,
                            to_mni=False,
                            write_local_bvecs=True,

--- a/docs/preprocessing.rst
+++ b/docs/preprocessing.rst
@@ -220,7 +220,7 @@ Examples of these plots follow:
 
 
 .. figure:: _static/sub-abcd_carpetplot.svg
-    :scale: 100%
+    :width: 100%
 
     For SHORELine higher scores appear more yellow, while lower scores
     are more blue. Not all slices contain the same number of voxels,

--- a/docs/preprocessing.rst
+++ b/docs/preprocessing.rst
@@ -220,7 +220,7 @@ Examples of these plots follow:
 
 
 .. figure:: _static/sub-abcd_carpetplot.svg
-    :width: 100%
+    :scale: 100%
 
     For SHORELine higher scores appear more yellow, while lower scores
     are more blue. Not all slices contain the same number of voxels,
@@ -517,7 +517,7 @@ Susceptibility Distortion Correction (SDC)
 
 The PEPOLAR and SyN-SDC workflows from FMRIPREP are copied here.
 They operate on the output of reference estimation, after head
-motion correction. For a complete list of possibilties here, see
+motion correction. For a complete list of possibilities here, see
 :ref:`merging`.
 
 .. _resampling:

--- a/qsiprep/interfaces/ants.py
+++ b/qsiprep/interfaces/ants.py
@@ -5,7 +5,7 @@ import logging
 
 from nipype.interfaces.base import (TraitedSpec, CommandLineInputSpec, BaseInterfaceInputSpec,
                                     CommandLine, File, traits, isdefined, InputMultiObject,
-                                    OutputMultiObject)
+                                    OutputMultiObject, SimpleInterface)
 from nipype.interfaces import ants
 from nipype.utils.filemanip import split_filename
 LOGGER = logging.getLogger('nipype.interface')
@@ -144,3 +144,16 @@ class ImageMath(CommandLine):
         outputs = self.output_spec().get()
         outputs['out_file'] = op.abspath(self._gen_filename('out_file'))
         return outputs
+
+
+class _ANTsBBRInputSpec(ants.registration.RegistrationInputSpec):
+    wm_seg = File(exists=True)
+
+
+class _ANTsBBROutputSpec(TraitedSpec):
+    forward_transforms = OutputMultiObject(File())
+
+
+class ANTsBBR(SimpleInterface):
+    input_spec = _ANTsBBRInputSpec
+    output_spec = _ANTsBBROutputSpec

--- a/qsiprep/niworkflows/viz/utils.py
+++ b/qsiprep/niworkflows/viz/utils.py
@@ -347,12 +347,13 @@ def plot_registration(anat_nii, div_id, plot_params=None,
 
     # dual mask
     dual_mask = contour is not None and np.array_equal(
-        np.unique(contour.get_data()), [0, 1, 2])
+        np.unique(contour.get_data().astype(np.uint8)), [0, 1, 2])
 
     if dual_mask:
         contour_data = contour.get_data()
         outer_mask = nlimage.new_img_like(contour, contour_data == 1)
         inner_mask = nlimage.new_img_like(contour, contour_data == 2)
+        all_mask = nlimage.new_img_like(contour, contour_data > 0)
 
     # Plot each cut axis
     for i, mode in enumerate(list(order)):
@@ -373,6 +374,7 @@ def plot_registration(anat_nii, div_id, plot_params=None,
             kwargs = {'levels': [0.5], 'linewidths': 0.75}
             display.add_contours(inner_mask, colors='b', **kwargs)
             display.add_contours(outer_mask, colors='r', **kwargs)
+            display.add_contours(all_mask, colors='c', **kwargs)
         elif contour is not None:
             display.add_contours(contour, colors='b', levels=[0.5],
                                  linewidths=0.5)

--- a/qsiprep/niworkflows/viz/utils.py
+++ b/qsiprep/niworkflows/viz/utils.py
@@ -345,6 +345,15 @@ def plot_registration(anat_nii, div_id, plot_params=None,
         white = nlimage.new_img_like(contour, contour_data == 2)
         pial = nlimage.new_img_like(contour, contour_data >= 2)
 
+    # dual mask
+    dual_mask = contour is not None and np.array_equal(
+        np.unique(contour.get_data()), [0, 1, 2])
+
+    if dual_mask:
+        contour_data = contour.get_data()
+        outer_mask = nlimage.new_img_like(contour, contour_data == 1)
+        inner_mask = nlimage.new_img_like(contour, contour_data == 2)
+
     # Plot each cut axis
     for i, mode in enumerate(list(order)):
         plot_params['display_mode'] = mode
@@ -360,6 +369,10 @@ def plot_registration(anat_nii, div_id, plot_params=None,
             kwargs = {'levels': [0.5], 'linewidths': 0.5}
             display.add_contours(white, colors='b', **kwargs)
             display.add_contours(pial, colors='r', **kwargs)
+        elif dual_mask:
+            kwargs = {'levels': [0.5], 'linewidths': 0.75}
+            display.add_contours(inner_mask, colors='b', **kwargs)
+            display.add_contours(outer_mask, colors='r', **kwargs)
         elif contour is not None:
             display.add_contours(contour, colors='b', levels=[0.5],
                                  linewidths=0.5)

--- a/qsiprep/viz/config.json
+++ b/qsiprep/viz/config.json
@@ -115,7 +115,7 @@
               "name": "epi/b0ref",
               "file_pattern":"dwi/.*_b0ref\\.",
               "title": "b=0 Reference Image",
-              "description": "The b=0 image used for coregistration to T1 before and after sharpening. Tentative brain mask is in blue.",
+              "description": "b=0 template and final mask output.",
               "imgtype": "svg+xml"
             },
             {

--- a/qsiprep/viz/config.json
+++ b/qsiprep/viz/config.json
@@ -115,7 +115,7 @@
               "name": "epi/b0ref",
               "file_pattern":"dwi/.*_b0ref\\.",
               "title": "b=0 Reference Image",
-              "description": "b=0 template and final mask output.",
+              "description": "b=0 template and final mask output. The t1 and signal intersection mask is blue, their xor is red and the entire mask is plotted in cyan.",
               "imgtype": "svg+xml"
             },
             {

--- a/qsiprep/workflows/dwi/base.py
+++ b/qsiprep/workflows/dwi/base.py
@@ -377,6 +377,7 @@ Diffusion data preprocessing
             ('outputnode.original_files', 'inputnode.original_files')]),
         (inputnode, hmc_wf, [
             ('t1_brain', 'inputnode.t1_brain'),
+            ('t1_mask', 'inputnode.t1_mask'),
             ('t1_2_mni_reverse_transform', 'inputnode.t1_2_mni_reverse_transform')]),
         (pre_hmc_wf, outputnode, [
             ('outputnode.qc_file', 'raw_qc_file'),

--- a/qsiprep/workflows/dwi/derivatives.py
+++ b/qsiprep/workflows/dwi/derivatives.py
@@ -33,9 +33,9 @@ def init_dwi_derivatives_wf(output_prefix,
     inputnode = pe.Node(
         niu.IdentityInterface(fields=[
             'source_file', 'dwi_t1', 'dwi_mask_t1', 'cnr_map_t1', 'bvals_t1', 'bvecs_t1',
-            'local_bvecs_t1', 't1_b0_ref', 't1_b0_series', 'gradient_table_t1', 'dwi_mni',
+            'local_bvecs_t1', 't1_b0_ref', 'gradient_table_t1', 'dwi_mni',
             'dwi_mask_mni', 'cnr_map_mni', 'bvals_mni', 'bvecs_mni', 'local_bvecs_mni',
-            'mni_b0_ref', 'mni_b0_series', 'gradient_table_mni', 'confounds',
+            'mni_b0_ref', 'gradient_table_mni', 'confounds',
             'hmc_optimization_data', 'series_qc'
         ]),
         name='inputnode')
@@ -100,17 +100,6 @@ def init_dwi_derivatives_wf(output_prefix,
             name='ds_t1_b0_ref',
             run_without_submitting=True,
             mem_gb=DEFAULT_MEMORY_MIN_GB)
-        ds_t1_b0_series = pe.Node(
-            DerivativesDataSink(
-                source_file=source_file,
-                base_directory=output_dir,
-                space='T1w',
-                suffix='b0series',
-                extension='.nii.gz',
-                compress=True),
-            name='ds_t1_b0_series',
-            run_without_submitting=True,
-            mem_gb=DEFAULT_MEMORY_MIN_GB)
         ds_dwi_mask_t1 = pe.Node(
             DerivativesDataSink(
                 source_file=source_file,
@@ -152,7 +141,6 @@ def init_dwi_derivatives_wf(output_prefix,
             (inputnode, ds_bvals_t1, [('bvals_t1', 'in_file')]),
             (inputnode, ds_bvecs_t1, [('bvecs_t1', 'in_file')]),
             (inputnode, ds_t1_b0_ref, [('t1_b0_ref', 'in_file')]),
-            (inputnode, ds_t1_b0_series, [('t1_b0_series', 'in_file')]),
             (inputnode, ds_dwi_mask_t1, [('dwi_mask_t1', 'in_file')]),
             (inputnode, ds_cnr_map_t1, [('cnr_map_t1', 'in_file')]),
             (inputnode, ds_gradient_table_t1, [('gradient_table_t1', 'in_file')])
@@ -219,17 +207,6 @@ def init_dwi_derivatives_wf(output_prefix,
             name='ds_mni_b0_ref',
             run_without_submitting=True,
             mem_gb=DEFAULT_MEMORY_MIN_GB)
-        ds_mni_b0_series = pe.Node(
-            DerivativesDataSink(
-                source_file=source_file,
-                base_directory=output_dir,
-                space=template,
-                suffix='b0series',
-                extension='.nii.gz',
-                compress=True),
-            name='ds_mni_b0_series',
-            run_without_submitting=True,
-            mem_gb=DEFAULT_MEMORY_MIN_GB)
         ds_dwi_mask_mni = pe.Node(
             DerivativesDataSink(
                 source_file=source_file,
@@ -258,7 +235,6 @@ def init_dwi_derivatives_wf(output_prefix,
             (inputnode, ds_bvals_mni, [('bvals_mni', 'in_file')]),
             (inputnode, ds_bvecs_mni, [('bvecs_mni', 'in_file')]),
             (inputnode, ds_mni_b0_ref, [('mni_b0_ref', 'in_file')]),
-            (inputnode, ds_mni_b0_series, [('mni_b0_series', 'in_file')]),
             (inputnode, ds_dwi_mask_mni, [('dwi_mask_mni', 'in_file')]),
             (inputnode, ds_gradient_table_mni, [('gradient_table_mni', 'in_file')])
             ])

--- a/qsiprep/workflows/dwi/finalize.py
+++ b/qsiprep/workflows/dwi/finalize.py
@@ -181,7 +181,6 @@ def init_dwi_finalize_wf(scan_groups,
         all_dwis = ['/fake/testing/path.nii.gz']
         fieldmap_info = {'suffix': None}
 
-    fieldmap_type = fieldmap_info['suffix']
     mem_gb = {'filesize': 1, 'resampled': 1, 'largemem': 1}
     dwi_nvols = 10
 
@@ -229,8 +228,8 @@ def init_dwi_finalize_wf(scan_groups,
     outputnode = pe.Node(
         niu.IdentityInterface(fields=[
             'dwi_t1', 'dwi_mask_t1', 'cnr_map_t1', 'bvals_t1', 'bvecs_t1', 'local_bvecs_t1',
-            't1_b0_ref', 't1_b0_series', 'dwi_mni', 'dwi_mask_mni', 'cnr_map_mni', 'bvals_mni',
-            'bvecs_mni', 'local_bvecs_mni', 'mni_b0_ref', 'mni_b0_series', 'confounds',
+            't1_b0_ref', 'dwi_mni', 'dwi_mask_mni', 'cnr_map_mni', 'bvals_mni',
+            'bvecs_mni', 'local_bvecs_mni', 'mni_b0_ref', 'confounds',
             'gradient_table_mni', 'gradient_table_t1', 'hmc_optimization_data'
         ]),
         name='outputnode')
@@ -301,7 +300,6 @@ def init_dwi_finalize_wf(scan_groups,
           ('bvecs_t1', 'inputnode.bvecs_t1'),
           ('local_bvecs_t1', 'inputnode.local_bvecs_t1'),
           ('t1_b0_ref', 'inputnode.t1_b0_ref'),
-          ('t1_b0_series', 'inputnode.t1_b0_series'),
           ('gradient_table_t1', 'inputnode.gradient_table_t1'),
           ('dwi_mni', 'inputnode.dwi_mni'),
           ('dwi_mask_mni', 'inputnode.dwi_mask_mni'),
@@ -310,7 +308,6 @@ def init_dwi_finalize_wf(scan_groups,
           ('bvecs_mni', 'inputnode.bvecs_mni'),
           ('local_bvecs_mni', 'inputnode.local_bvecs_mni'),
           ('mni_b0_ref', 'inputnode.mni_b0_ref'),
-          ('mni_b0_series', 'inputnode.mni_b0_series'),
           ('gradient_table_mni', 'inputnode.gradient_table_mni'),
           ('confounds', 'inputnode.confounds'),
           ('hmc_optimization_data', 'inputnode.hmc_optimization_data')])
@@ -325,11 +322,10 @@ def init_dwi_finalize_wf(scan_groups,
     ])
 
     if "T1w" in output_spaces:
-        transform_dwis_t1 = init_dwi_trans_wf(name='transform_dwis_t1',
+        transform_dwis_t1 = init_dwi_trans_wf(source_file=source_file,
+                                              name='transform_dwis_t1',
                                               template="ACPC",
                                               mem_gb=mem_gb['resampled'],
-                                              use_fieldwarp=(fieldmap_type is not None
-                                                             or use_syn),
                                               omp_nthreads=omp_nthreads,
                                               output_resolution=output_resolution,
                                               use_compression=False,
@@ -383,11 +379,10 @@ def init_dwi_finalize_wf(scan_groups,
             (gtab_t1, outputnode, [('gradient_file', 'gradient_table_t1')])])
 
     if "template" in output_spaces:
-        transform_dwis_mni = init_dwi_trans_wf(name='transform_dwis_mni',
+        transform_dwis_mni = init_dwi_trans_wf(source_file=source_file,
+                                               name='transform_dwis_mni',
                                                template=template,
                                                mem_gb=mem_gb['resampled'],
-                                               use_fieldwarp=(fieldmap_type is not None
-                                                              or use_syn),
                                                omp_nthreads=omp_nthreads,
                                                output_resolution=output_resolution,
                                                use_compression=False,

--- a/qsiprep/workflows/dwi/fsl.py
+++ b/qsiprep/workflows/dwi/fsl.py
@@ -234,8 +234,7 @@ def init_fsl_hmc_wf(scan_groups,
     workflow.connect([
         # Use the distorted mask for eddy
         (gather_inputs, distorted_merge, [('topup_imain', 'in_files')]),
-        (distorted_merge, pre_eddy_b0_ref_wf, [('out_avg', 'inputnode.b0_template')]),
-        (pre_eddy_b0_ref_wf, eddy, [('outputnode.dwi_mask', 'in_mask')])])
+        (distorted_merge, pre_eddy_b0_ref_wf, [('out_avg', 'inputnode.b0_template')])])
 
     if fieldmap_type in ('fieldmap', 'phasediff', 'phase', 'syn'):
 

--- a/qsiprep/workflows/dwi/fsl.py
+++ b/qsiprep/workflows/dwi/fsl.py
@@ -249,8 +249,6 @@ def init_fsl_hmc_wf(scan_groups,
                 ('dwi_file', 'inputnode.b0_ref')]),
             (b0_ref_brain_to_lps, b0_sdc_wf, [
                 ('dwi_file', 'b0_ref_brain')]),
-            (b0_ref_mask_to_lps, b0_sdc_wf, [
-                ('dwi_file', 'b0_mask')]),
             (inputnode, b0_sdc_wf, [
                 ('t1_brain', 'inputnode.t1_brain'),
                 ('t1_2_mni_reverse_transform',

--- a/qsiprep/workflows/dwi/fsl.py
+++ b/qsiprep/workflows/dwi/fsl.py
@@ -247,8 +247,6 @@ def init_fsl_hmc_wf(scan_groups,
             # Send to SDC workflow
             (b0_ref_to_lps, b0_sdc_wf, [
                 ('dwi_file', 'inputnode.b0_ref')]),
-            (b0_ref_brain_to_lps, b0_sdc_wf, [
-                ('dwi_file', 'b0_ref_brain')]),
             (inputnode, b0_sdc_wf, [
                 ('t1_brain', 'inputnode.t1_brain'),
                 ('t1_2_mni_reverse_transform',

--- a/qsiprep/workflows/dwi/fsl.py
+++ b/qsiprep/workflows/dwi/fsl.py
@@ -133,7 +133,6 @@ def init_fsl_hmc_wf(scan_groups,
 
     # Convert the b=0 template from pre_eddy_b0_ref to LPS+
     b0_ref_to_lps = pe.Node(ConformDwi(orientation="LPS"), name='b0_ref_to_lps')
-    b0_ref_brain_to_lps = pe.Node(ConformDwi(orientation="LPS"), name='b0_ref_brain_to_lps')
     b0_ref_mask_to_lps = pe.Node(ConformDwi(orientation="LPS"), name='b0_ref_mask_to_lps')
 
     workflow.connect([
@@ -184,6 +183,7 @@ def init_fsl_hmc_wf(scan_groups,
             (slice_quality, 'slice_quality'),
             (slice_quality, 'hmc_optimization_data')]),
         (eddy, spm_motion, [('out_parameter', 'eddy_motion')]),
+        (b0_ref_mask_to_lps, outputnode, [('dwi_file', 'b0_template_mask')]),
         (spm_motion, outputnode, [('spm_motion_file', 'motion_params')])
     ])
 
@@ -220,7 +220,6 @@ def init_fsl_hmc_wf(scan_groups,
             (topup, unwarped_mean, [('out_corrected', 'in_files')]),
             (unwarped_mean, pre_eddy_b0_ref_wf, [('out_avg', 'inputnode.b0_template')]),
             (b0_ref_to_lps, outputnode, [('dwi_file', 'b0_template')]),
-            (b0_ref_mask_to_lps, outputnode, [('dwi_file', 'b0_template_mask')]),
             # Save reports
             (gather_inputs, topup_summary, [('topup_report', 'summary')]),
             (topup_summary, ds_report_topupsummary, [('out_report', 'in_file')]),
@@ -256,15 +255,12 @@ def init_fsl_hmc_wf(scan_groups,
             (b0_sdc_wf, outputnode, [
                 ('outputnode.out_warp', 'to_dwi_ref_warps'),
                 ('outputnode.method', 'sdc_method'),
-                ('outputnode.b0_ref', 'b0_template'),
-                ('outputnode.b0_mask', 'b0_template_mask')])])
+                ('outputnode.b0_ref', 'b0_template')])])
 
     else:
         outputnode.inputs.sdc_method = "None"
         workflow.connect([
             (b0_ref_to_lps, outputnode, [
-                ('dwi_file', 'b0_template')]),
-            (b0_ref_mask_to_lps, outputnode, [
-                ('dwi_file', 'b0_template_mask')])])
+                ('dwi_file', 'b0_template')])])
 
     return workflow

--- a/qsiprep/workflows/dwi/fsl.py
+++ b/qsiprep/workflows/dwi/fsl.py
@@ -12,16 +12,16 @@ from nipype import logging
 
 from nipype.pipeline import engine as pe
 from nipype.interfaces import utility as niu
-from nipype.interfaces import fsl, afni, ants
+from nipype.interfaces import fsl, ants
 
 from ...interfaces.eddy import GatherEddyInputs, ExtendedEddy, Eddy2SPMMotion
-from ...interfaces.images import SplitDWIs, ConformDwi
+from ...interfaces.images import SplitDWIs, ConformDwi, IntraModalMerge
 from ...interfaces.reports import TopupSummary
 from ...interfaces import DerivativesDataSink
 from ...engine import Workflow
 
 # dwi workflows
-from .util import init_enhance_and_skullstrip_dwi_wf
+from .util import init_dwi_reference_wf
 from ..fieldmap.base import init_sdc_wf
 
 DEFAULT_MEMORY_MIN_GB = 0.01
@@ -84,14 +84,18 @@ def init_fsl_hmc_wf(scan_groups,
             List of single b=0 volumes
         original_files: list
             List of the files from which each DWI volume came.
-
+        t1_brain: str
+            Skull stripped T1w image
+        t1_mask: str
+            mask for t1_brain
 
     """
 
     inputnode = pe.Node(
         niu.IdentityInterface(
             fields=['dwi_file', 'bvec_file', 'bval_file', 'b0_indices', 'b0_images',
-                    'original_files', 't1_brain', 't1_2_mni_reverse_transform']),
+                    'original_files', 't1_brain', 't1_mask', 't1_seg',
+                    't1_2_mni_reverse_transform']),
         name='inputnode')
 
     outputnode = pe.Node(
@@ -114,19 +118,18 @@ def init_fsl_hmc_wf(scan_groups,
     with open(eddy_cfg_file, "r") as f:
         eddy_args = json.load(f)
 
-    # Use run in parallel if possible
+    # Run in parallel if possible
     LOGGER.info("Using %d threads in eddy", omp_nthreads)
     eddy_args["num_threads"] = omp_nthreads
+    pre_eddy_b0_ref_wf = init_dwi_reference_wf(register_t1=True, source_file=source_file,
+                                               name='pre_eddy_b0_ref_wf')
     eddy = pe.Node(ExtendedEddy(**eddy_args), name="eddy")
     spm_motion = pe.Node(Eddy2SPMMotion(), name="spm_motion")
+
     # Convert eddy outputs back to LPS+, split them
-    pre_topup_lps = pe.Node(ConformDwi(orientation="LPS"), name='pre_topup_lps')
-    pre_topup_enhance = init_enhance_and_skullstrip_dwi_wf(name='pre_topup_enhance')
     back_to_lps = pe.Node(ConformDwi(orientation="LPS"), name='back_to_lps')
     cnr_lps = pe.Node(ConformDwi(orientation="LPS"), name='cnr_lps')
     split_eddy_lps = pe.Node(SplitDWIs(b0_threshold=b0_threshold), name="split_eddy_lps")
-    mean_b0_lps = pe.Node(ants.AverageImages(dimension=3, normalize=True), name='mean_b0_lps')
-    lps_b0_enhance = init_enhance_and_skullstrip_dwi_wf(name='lps_b0_enhance')
 
     workflow.connect([
         # These images and gradients should be in LAS+
@@ -135,6 +138,10 @@ def init_fsl_hmc_wf(scan_groups,
             ('bval_file', 'bval_file'),
             ('bvec_file', 'bvec_file'),
             ('original_files', 'original_files')]),
+        (inputnode, pre_eddy_b0_ref_wf, [
+            ('t1_brain', 'inputnode.t1_brain'),
+            ('t1_mask', 'inputnode.t1_mask'),
+            ('t1_seg', 'inputnode.t1_seg')]),
         (gather_inputs, eddy, [
             ('eddy_indices', 'in_index'),
             ('eddy_acqp', 'in_acqp')]),
@@ -142,13 +149,8 @@ def init_fsl_hmc_wf(scan_groups,
             ('dwi_file', 'in_file'),
             ('bval_file', 'in_bval'),
             ('bvec_file', 'in_bvec')]),
-        (gather_inputs, pre_topup_lps, [
-            ('pre_topup_image', 'dwi_file')]),
-        (gather_inputs, outputnode, [('forward_transforms', 'to_dwi_ref_affines')]),
-        (pre_topup_lps, pre_topup_enhance, [
-            ('dwi_file', 'inputnode.in_file')]),
-        (pre_topup_enhance, outputnode, [
-            ('outputnode.bias_corrected_file', 'pre_sdc_template')]),
+        (gather_inputs, outputnode, [
+            ('forward_transforms', 'to_dwi_ref_affines')]),
         (eddy, back_to_lps, [
             ('out_corrected', 'dwi_file'),
             ('out_rotated_bvecs', 'bvec_file')]),
@@ -164,8 +166,6 @@ def init_fsl_hmc_wf(scan_groups,
             ('bvec_files', 'bvec_files_to_transform'),
             ('bval_files', 'bval_files'),
             ('b0_indices', 'b0_indices')]),
-        (split_eddy_lps, mean_b0_lps, [('b0_images', 'images')]),
-        (mean_b0_lps, lps_b0_enhance, [('output_average_image', 'inputnode.in_file')]),
         (eddy, cnr_lps, [('out_cnr_maps', 'dwi_file')]),
         (cnr_lps, outputnode, [('dwi_file', 'cnr_map')]),
         (eddy, outputnode, [
@@ -192,36 +192,52 @@ def init_fsl_hmc_wf(scan_groups,
             name='ds_report_topupsummary',
             run_without_submitting=True,
             mem_gb=DEFAULT_MEMORY_MIN_GB)
-        # Enhance and skullstrip the TOPUP output to get a mask for eddy
-        unwarped_mean = pe.Node(afni.TStat(outputtype='NIFTI_GZ'), name='unwarped_mean')
-        unwarped_enhance = init_enhance_and_skullstrip_dwi_wf(name='unwarped_enhance')
 
+        # Enhance and skullstrip the TOPUP output to get a mask for eddy
+        unwarped_mean = pe.Node(IntraModalMerge(hmc=False, to_lps=False), name='unwarped_mean')
         workflow.connect([
+            # There will be no SDC warps, they are applied by eddy
+            (gather_inputs, outputnode, [('forward_warps', 'to_dwi_ref_warps')]),
             (gather_inputs, topup, [
                 ('topup_datain', 'encoding_file'),
                 ('topup_imain', 'in_file'),
                 ('topup_config', 'config')]),
-            (gather_inputs, topup_summary, [('topup_report', 'summary')]),
-            (topup_summary, ds_report_topupsummary, [('out_report', 'in_file')]),
-            (gather_inputs, outputnode, [('forward_warps', 'to_dwi_ref_warps')]),
-            (topup, unwarped_mean, [('out_corrected', 'in_file')]),
-            (unwarped_mean, unwarped_enhance, [('out_file', 'inputnode.in_file')]),
-            (unwarped_enhance, eddy, [('outputnode.mask_file', 'in_mask')]),
             (topup, eddy, [
                 ('out_field', 'field')]),
-            (lps_b0_enhance, outputnode, [
-                ('outputnode.bias_corrected_file', 'b0_template'),
-                ('outputnode.mask_file', 'b0_template_mask')]),
-            ])
+            # Use corrected images from TOPUP to make a mask for eddy
+            (topup, unwarped_mean, [('out_corrected', 'in_files')]),
+            (unwarped_mean, pre_eddy_b0_ref_wf, [('out_file', 'inputnode.b0_template')]),
+            (pre_eddy_b0_ref_wf, eddy, [('outputnode.mask_file', 'in_mask')]),
+            # Save reports
+            (gather_inputs, topup_summary, [('topup_report', 'summary')]),
+            (topup_summary, ds_report_topupsummary, [('out_report', 'in_file')]),
+        ])
         return workflow
 
-    # Enhance and skullstrip the TOPUP output to get a mask for eddy
-    distorted_enhance = init_enhance_and_skullstrip_dwi_wf(name='distorted_enhance')
+    # The topup inputs will only have one PE direction,
+    # so they can be used to make a b=0 reference to mask for eddy
+    distorted_merge = pe.Node(
+        IntraModalMerge(hmc=True, to_lps=False), name='distorted_merge')
     workflow.connect([
         # Use the distorted mask for eddy
-        (gather_inputs, distorted_enhance, [('pre_topup_image', 'inputnode.in_file')]),
-        (distorted_enhance, eddy, [('outputnode.mask_file', 'in_mask')]),
+        (gather_inputs, distorted_merge, [('topup_imain', 'in_files')]),
+        (distorted_merge, pre_eddy_b0_ref_wf, [('out_avg', 'inputnode.b0_template')]),
+        (pre_eddy_b0_ref_wf, eddy, [('outputnode.mask_file', 'in_mask')])])
+
+    # Convert the b=0 template from pre_eddy_b0_ref to LPS+
+    b0_ref_to_lps = pe.Node(ConformDwi(orientation="LPS"), name='b0_ref_to_lps')
+    b0_ref_brain_to_lps = pe.Node(ConformDwi(orientation="LPS"), name='b0_ref_brain_to_lps')
+    b0_ref_mask_to_lps = pe.Node(ConformDwi(orientation="LPS"), name='b0_ref_mask_to_lps')
+    workflow.connect([
+        # Convert distorted ref to LPS+
+        (pre_eddy_b0_ref_wf, b0_ref_to_lps, [
+            ('outputnode.bias_corrected_file', 'dwi_file')]),
+        (pre_eddy_b0_ref_wf, b0_ref_brain_to_lps, [
+            ('outputnode.skull_stripped_file', 'dwi_file')]),
+        (pre_eddy_b0_ref_wf, b0_ref_mask_to_lps, [
+            ('outputnode.mask_file', 'dwi_file')]),
     ])
+
     if fieldmap_type in ('fieldmap', 'phasediff', 'phase', 'syn'):
 
         outputnode.inputs.sdc_method = fieldmap_type
@@ -230,11 +246,13 @@ def init_fsl_hmc_wf(scan_groups,
             fmap_demean=fmap_demean, fmap_bspline=fmap_bspline)
 
         workflow.connect([
-            # Calculate distortion correction on eddy-corrected data
-            (lps_b0_enhance, b0_sdc_wf, [
-                ('outputnode.bias_corrected_file', 'inputnode.b0_ref'),
-                ('outputnode.skull_stripped_file', 'inputnode.b0_ref_brain'),
-                ('outputnode.mask_file', 'inputnode.b0_mask')]),
+            # Send to SDC workflow
+            (b0_ref_to_lps, b0_sdc_wf, [
+                ('dwi_file', 'inputnode.b0_ref')]),
+            (b0_ref_brain_to_lps, b0_sdc_wf, [
+                ('dwi_file', 'b0_ref_brain')]),
+            (b0_ref_mask_to_lps, b0_sdc_wf, [
+                ('dwi_file', 'b0_mask')]),
             (inputnode, b0_sdc_wf, [
                 ('t1_brain', 'inputnode.t1_brain'),
                 ('t1_2_mni_reverse_transform',
@@ -250,9 +268,9 @@ def init_fsl_hmc_wf(scan_groups,
     else:
         outputnode.inputs.sdc_method = "None"
         workflow.connect([
-            (lps_b0_enhance, outputnode, [
-                ('outputnode.skull_stripped_file', 'b0_template'),
-                ('outputnode.mask_file', 'b0_template_mask')]),
-            ])
+            (b0_ref_to_lps, outputnode, [
+                ('dwi_file', 'b0_template')]),
+            (b0_ref_mask_to_lps, outputnode, [
+                ('dwi_file', 'b0_template_mask')])])
 
     return workflow

--- a/qsiprep/workflows/dwi/fsl.py
+++ b/qsiprep/workflows/dwi/fsl.py
@@ -161,7 +161,8 @@ def init_fsl_hmc_wf(scan_groups,
             ('bvec_file', 'in_bvec')]),
         (pre_eddy_b0_ref_wf, eddy, [('outputnode.dwi_mask', 'in_mask')]),
         (gather_inputs, outputnode, [
-            ('forward_transforms', 'to_dwi_ref_affines')]),
+            ('forward_transforms', 'to_dwi_ref_affines'),
+            ('pre_topup_image', 'pre_sdc_template')]),
         (eddy, back_to_lps, [
             ('out_corrected', 'dwi_file'),
             ('out_rotated_bvecs', 'bvec_file')]),
@@ -217,7 +218,7 @@ def init_fsl_hmc_wf(scan_groups,
                 ('out_field', 'field')]),
             # Use corrected images from TOPUP to make a mask for eddy
             (topup, unwarped_mean, [('out_corrected', 'in_files')]),
-            (unwarped_mean, pre_eddy_b0_ref_wf, [('out_file', 'inputnode.b0_template')]),
+            (unwarped_mean, pre_eddy_b0_ref_wf, [('out_avg', 'inputnode.b0_template')]),
             (b0_ref_to_lps, outputnode, [('dwi_file', 'b0_template')]),
             (b0_ref_mask_to_lps, outputnode, [('dwi_file', 'b0_template_mask')]),
             # Save reports

--- a/qsiprep/workflows/dwi/hmc.py
+++ b/qsiprep/workflows/dwi/hmc.py
@@ -97,7 +97,7 @@ def init_dwi_hmc_wf(hmc_transform, hmc_model, hmc_align_to, source_file,
     # Make a mask from the output template. It is bias-corrected, so good for masking
     # but bad for using as a b=0 for modeling.
     b0_template_mask = init_dwi_reference_wf(register_t1=True, name="b0_template_mask",
-                                             gen_report=True, source_file=source_file)
+                                             gen_report=False, source_file=source_file)
 
     workflow.connect([
         (inputnode, match_transforms, [('dwi_files', 'dwi_files'),
@@ -113,8 +113,8 @@ def init_dwi_hmc_wf(hmc_transform, hmc_model, hmc_align_to, source_file,
         (b0_hmc_wf, b0_template_mask, [
             ('outputnode.final_template', 'inputnode.b0_template')]),
         (b0_template_mask, outputnode, [
-            ('outputnode.skull_stripped_file', 'final_template_brain'),
-            ('outputnode.mask_file', 'final_template_mask')
+            ('outputnode.ref_image_brain', 'final_template_brain'),
+            ('outputnode.dwi_mask', 'final_template_mask')
         ])
     ])
 

--- a/qsiprep/workflows/dwi/hmc.py
+++ b/qsiprep/workflows/dwi/hmc.py
@@ -150,7 +150,7 @@ def init_dwi_hmc_wf(hmc_transform, hmc_model, hmc_align_to, source_file,
         (b0_hmc_wf, dwi_model_hmc_wf, [
             ('outputnode.aligned_images', 'inputnode.warped_b0_images')]),
         (b0_template_mask, dwi_model_hmc_wf, [
-            ('outputnode.mask_file', 'inputnode.warped_b0_mask')]),
+            ('outputnode.dwi_mask', 'inputnode.warped_b0_mask')]),
         (inputnode, dwi_model_hmc_wf, [
             ('dwi_files', 'inputnode.dwi_files'),
             ('b0_indices', 'inputnode.b0_indices'),

--- a/qsiprep/workflows/dwi/hmc_sdc.py
+++ b/qsiprep/workflows/dwi/hmc_sdc.py
@@ -74,7 +74,7 @@ def init_qsiprep_hmcsdc_wf(scan_groups,
         niu.IdentityInterface(
             fields=['dwi_file', 'bvec_file', 'bval_file', 'rpe_b0',
                     'original_files', 'rpe_b0_info', 'hmc_optimization_data', 't1_brain',
-                    't1_2_mni_reverse_transform']),
+                    't1_2_mni_reverse_transform', 't1_mask']),
         name='inputnode')
 
     outputnode = pe.Node(
@@ -118,11 +118,6 @@ def init_qsiprep_hmcsdc_wf(scan_groups,
         scan_groups['fieldmap_info'], dwi_metadata, omp_nthreads=omp_nthreads,
         fmap_demean=fmap_demean, fmap_bspline=fmap_bspline)
     b0_sdc_wf.inputs.inputnode.template = template
-
-    # Create a b=0 reference for coregistration
-    dwi_ref_wf = init_dwi_reference_wf(name="dwi_ref_wf",
-                                       gen_report=True,
-                                       source_file=source_file)
 
     # Impute slice data if requested
     slice_qc = pe.Node(SliceQC(impute_slice_threshold=impute_slice_threshold), name="slice_qc")

--- a/qsiprep/workflows/dwi/intramodal_template.py
+++ b/qsiprep/workflows/dwi/intramodal_template.py
@@ -88,15 +88,10 @@ def init_intramodal_template_wf(inputs_list, t1w_source_file, reportlets_dir, tr
         runtime_opts = {'num_cores': omp_nthreads, 'parallel_control': 2}
     ants_mvtc2 = pe.Node(MultivariateTemplateConstruction2(dimension=3, **runtime_opts),
                          name='ants_mvtc2')
-    intramodal_template_mask = init_skullstrip_b0_wf(name="intramodal_template_mask")
 
     workflow.connect([
         (merge_inputs, rename_inputs, [('out', 'in_file')]),
         (rename_inputs, ants_mvtc2, [('out_file', 'input_images')]),
-        (intramodal_template_mask, outputnode, [
-            ('outputnode.mask_file', 'intramodal_template_mask')]),
-        (ants_mvtc2, intramodal_template_mask, [
-            ('templates', 'inputnode.in_file')]),
         (ants_mvtc2, split_outputs, [
             ('forward_transforms', 'inlist')]),
         (ants_mvtc2, outputnode, [
@@ -136,10 +131,10 @@ def init_intramodal_template_wf(inputs_list, t1w_source_file, reportlets_dir, tr
     return workflow
 
 
-def init_qsiprep_intramodal_template_wf(
-            inputs_list, transform="Rigid", num_iterations=2,
-            mem_gb=3, omp_nthreads=1, name="intramodal_template_wf"):
-    """Create an unbiased intramodal template for a subject. This aligns the b=0 references
+def init_qsiprep_intramodal_template_wf(inputs_list, transform="Rigid", num_iterations=2,
+                                        mem_gb=3, omp_nthreads=1, name="intramodal_template_wf"):
+    """Create an unbiased intramodal template for a subject.
+    This aligns the b=0 references
     from all the scans of a subject. Can be rigid, affine or nonlinear (BSplineSyN).
 
     **Parameters**

--- a/qsiprep/workflows/dwi/qc.py
+++ b/qsiprep/workflows/dwi/qc.py
@@ -6,7 +6,6 @@ Utility workflows
 ^^^^^^^^^^^^^^^^^
 
 .. autofunction:: init_dwi_reference_wf
-.. autofunction:: init_enhance_and_skullstrip_dwi_wf
 
 """
 from nipype.pipeline import engine as pe
@@ -25,13 +24,6 @@ DEFAULT_MEMORY_MIN_GB = 0.01
 def init_modelfree_qc_wf(dwi_files=None, name='dwi_qc_wf'):
     """
     This workflow runs DSI Studio's QC metrics
-
-    .. workflow::
-        :graph2use: orig
-        :simple_form: yes
-
-        from qsiprep.workflows.dwi.util import init_dwi_reference_wf
-        wf = init_dwi_reference_wf(omp_nthreads=1)
 
     **Parameters**
 

--- a/qsiprep/workflows/dwi/resampling.py
+++ b/qsiprep/workflows/dwi/resampling.py
@@ -23,13 +23,13 @@ from .qc import init_modelfree_qc_wf
 DEFAULT_MEMORY_MIN_GB = 0.01
 
 
-def init_dwi_trans_wf(template,
+def init_dwi_trans_wf(source_file,
+                      template,
                       mem_gb,
                       omp_nthreads,
                       output_resolution,
                       name='dwi_trans_wf',
                       use_compression=True,
-                      use_fieldwarp=False,
                       to_mni=False,
                       write_local_bvecs=False):
     """
@@ -128,6 +128,7 @@ generating a *preprocessed DWI run in {tpl} space*.
         niu.IdentityInterface(fields=[
             'itk_b0_to_t1',
             't1_mask',
+            't1_brain',
             'b0_to_intramodal_template_transforms',
             'intramodal_template_to_t1_warp',
             'intramodal_template_to_t1_affine',
@@ -232,15 +233,8 @@ generating a *preprocessed DWI run in {tpl} space*.
                     mem_gb=mem_gb * 3)
 
     extract_b0_series = pe.Node(ExtractB0s(), name="extract_b0_series")
-    mask_b0s = pe.Node(MaskB0Series(), name="mask_b0s")
-
-    # Use the T1w to make a final mask
-    resample_t1_mask = pe.Node(
-        ants.ApplyTransforms(dimension=3,
-                             transforms='identity',
-                             interpolation="MultiLabel"),
-        name='resample_t1_mask')
-    final_b0_ref = init_dwi_reference_wf()
+    final_b0_ref = init_dwi_reference_wf(register_t1=False, gen_report=True,
+                                         name='final_b0_ref', source_file=source_file)
 
     workflow.connect([
         (inputnode, rotate_gradients, [('bvec_files', 'bvec_files'),
@@ -262,13 +256,10 @@ generating a *preprocessed DWI run in {tpl} space*.
         (merge, extract_b0_series, [('out_file', 'dwi_series')]),
         (inputnode, extract_b0_series, [('b0_indices', 'b0_indices')]),
         (extract_b0_series, final_b0_ref, [('b0_average', 'inputnode.b0_template')]),
-        (extract_b0_series, resample_t1_mask, [('b0_average', 'reference_image')]),
-        (inputnode, resample_t1_mask, [('t1_mask', 'input_image')]),
-        (resample_t1_mask, final_b0_ref, [('output_image', 'inputnode.t1_prior_mask')]),
-        (final_b0_ref, outputnode, [('outputnode.ref_image', 'dwi_ref_resampled')]),
-        (extract_b0_series, mask_b0s, [('b0_series', 'b0_series')]),
-        (mask_b0s, outputnode, [('mask_file', 'resampled_dwi_mask')]),
-        (extract_b0_series, outputnode, [('b0_series', 'b0_series')])])
+        (inputnode, final_b0_ref, [('t1_mask', 'inputnode.t1_mask')]),
+        (final_b0_ref, outputnode, [
+            ('outputnode.ref_image', 'dwi_ref_resampled'),
+            ('outputnode.dwi_mask', 'resampled_dwi_mask')])])
 
     # Calculate QC metrics on the resampled data
     calculate_qc = init_modelfree_qc_wf(name='calculate_qc')

--- a/qsiprep/workflows/dwi/resampling.py
+++ b/qsiprep/workflows/dwi/resampling.py
@@ -41,7 +41,8 @@ def init_dwi_trans_wf(source_file,
         :simple_form: yes
 
         from qsiprep.workflows.dwi.resampling import init_dwi_trans_wf
-        wf = init_dwi_trans_wf(template='MNI152NLin2009cAsym',
+        wf = init_dwi_trans_wf(source_file='sub-1_dwi.nii.gz',
+                               template='MNI152NLin2009cAsym',
                                output_resolution=1.2,
                                mem_gb=3,
                                omp_nthreads=1)

--- a/qsiprep/workflows/dwi/resampling.py
+++ b/qsiprep/workflows/dwi/resampling.py
@@ -234,7 +234,7 @@ generating a *preprocessed DWI run in {tpl} space*.
                     mem_gb=mem_gb * 3)
 
     extract_b0_series = pe.Node(ExtractB0s(), name="extract_b0_series")
-    final_b0_ref = init_dwi_reference_wf(register_t1=False, gen_report=True,
+    final_b0_ref = init_dwi_reference_wf(register_t1=False, gen_report=True, desc='resampled',
                                          name='final_b0_ref', source_file=source_file)
 
     workflow.connect([

--- a/qsiprep/workflows/dwi/util.py
+++ b/qsiprep/workflows/dwi/util.py
@@ -12,10 +12,11 @@ Utility workflows
 import os
 from pathlib import Path
 import nibabel as nb
+import pkg_resources as pkgr
 
 from nipype.pipeline import engine as pe
 from nipype.utils.filemanip import split_filename
-from nipype.interfaces import utility as niu, fsl
+from nipype.interfaces import utility as niu, fsl, ants
 from ...niworkflows.interfaces import SimpleBeforeAfter
 from ...engine import Workflow
 from ...interfaces.ants import ImageMath
@@ -26,14 +27,19 @@ from ...interfaces.nilearn import EnhanceAndSkullstripB0
 DEFAULT_MEMORY_MIN_GB = 0.01
 
 
-def init_dwi_reference_wf(omp_nthreads=1, dwi_file=None, name='dwi_reference_wf',
-                          gen_report=False, source_file=None, desc="initial"):
+def init_dwi_reference_wf(omp_nthreads=1, dwi_file=None, register_t1=False,
+                          name='dwi_reference_wf', gen_report=False, source_file=None,
+                          desc="initial"):
     """
-    This workflow generates reference b=0 image.
+    This workflow generates reference b=0 image and a mask.
 
     The raw reference image is the target of :abbr:`HMC (head motion correction)`, and a
     contrast-enhanced reference is the subject of distortion correction, as well as
     boundary-based registration to T1w and template spaces.
+
+    A skull-stripped T1w image is downsampled to the resolution of the b0 input image
+    and registered to it. The T1w mask is used as a starting point for generating
+    The b=0 mask.
 
     .. workflow::
         :graph2use: orig
@@ -57,6 +63,12 @@ def init_dwi_reference_wf(omp_nthreads=1, dwi_file=None, name='dwi_reference_wf'
 
         b0_template
             the b0 template used as the motion correction reference
+        t1_brain
+            skull-stripped T1w image from the same subject
+        t1_mask
+            mask image for t1_brain
+        wm_seg
+            white matter segmentation from the T1w image
 
     **Outputs**
 
@@ -81,7 +93,7 @@ def init_dwi_reference_wf(omp_nthreads=1, dwi_file=None, name='dwi_reference_wf'
     workflow.__desc__ = """\
 """
     inputnode = pe.Node(
-        niu.IdentityInterface(fields=['b0_template', 't1_prior_mask']),
+        niu.IdentityInterface(fields=['b0_template', 't1_brain', 't1_mask', 't1_seg']),
         name='inputnode')
     outputnode = pe.Node(
         niu.IdentityInterface(fields=['dwi_file', 'raw_ref_image', 'ref_image', 'bias_image',
@@ -91,6 +103,30 @@ def init_dwi_reference_wf(omp_nthreads=1, dwi_file=None, name='dwi_reference_wf'
     # Simplify manually setting input image
     if dwi_file is not None:
         inputnode.inputs.b0_template = dwi_file
+
+    # b=0 images are too diverse and tricky to reliably mask.
+    # Instead register the t1w to the b=0 and use that brain mask
+    if register_t1:
+        affine_transform = pkgr.resource_filename('qsiprep', 'data/affine.json')
+        register_t1_to_raw = pe.Node(ants.Registration(), name='register_t1_to_raw')
+        t1_mask_to_b0 = pe.Node(ants.ApplyTransforms(), name='t1_mask_to_b0')
+        workflow.connect([
+            (inputnode, register_t1_to_raw, [
+                ('t1_brain', 'moving_image'),
+                ('b0_template', 'fixed_image'),
+                ('t1_mask', 'moving_mask')]),
+            (register_t1_to_raw, t1_mask_to_b0, [
+                ('forward_transforms', 'transforms')])])
+    else:
+        # T1w is already aligned
+        t1_mask_to_b0 = pe.Node(
+            ants.ApplyTransforms(transforms='identity'),
+            name='t1_mask_to_b0')
+
+    workflow.connect([
+        (inputnode, t1_mask_to_b0, [
+            ('t1_mask', 'in_file'),
+            ('b0_template', 'reference_image')])])
 
     enhance_and_skullstrip_dwi_wf = init_enhance_and_skullstrip_dwi_wf(
         omp_nthreads=omp_nthreads)

--- a/qsiprep/workflows/dwi/util.py
+++ b/qsiprep/workflows/dwi/util.py
@@ -116,6 +116,7 @@ def init_dwi_reference_wf(omp_nthreads=1, dwi_file=None, register_t1=False,
         workflow.connect([
             (inputnode, register_t1_to_raw, [
                 ('t1_brain', 'fixed_image'),
+                ('t1_mask', 'fixed_image_masks'),
                 ('b0_template', 'moving_image')]),
             (register_t1_to_raw, t1_mask_to_b0, [
                 ('forward_transforms', 'transforms')])])

--- a/qsiprep/workflows/dwi/util.py
+++ b/qsiprep/workflows/dwi/util.py
@@ -110,15 +110,15 @@ def init_dwi_reference_wf(omp_nthreads=1, dwi_file=None, register_t1=False,
         affine_transform = pkgr.resource_filename('qsiprep', 'data/affine.json')
         register_t1_to_raw = pe.Node(ants.Registration(from_file=affine_transform),
                                      name='register_t1_to_raw')
-        t1_mask_to_b0 = pe.Node(ants.ApplyTransforms(interpolation='MultiLabel'),
+        t1_mask_to_b0 = pe.Node(ants.ApplyTransforms(interpolation='MultiLabel',
+                                                     invert_transform_flags=[True]),
                                 name='t1_mask_to_b0')
         workflow.connect([
             (inputnode, register_t1_to_raw, [
                 ('t1_brain', 'fixed_image'),
-                ('b0_template', 'moving_image'),
-                ('t1_mask', 'fixed_image_masks')]),
+                ('b0_template', 'moving_image')]),
             (register_t1_to_raw, t1_mask_to_b0, [
-                ('reverse_transforms', 'transforms')])])
+                ('forward_transforms', 'transforms')])])
     else:
         # T1w is already aligned
         t1_mask_to_b0 = pe.Node(

--- a/qsiprep/workflows/fieldmap/syn.py
+++ b/qsiprep/workflows/fieldmap/syn.py
@@ -159,8 +159,6 @@ template [@fieldmapless3].
         dimension=3, float=True, interpolation='LanczosWindowedSinc'),
         name='unwarp_ref')
 
-    skullstrip_b0_wf = init_skullstrip_b0_wf()
-
     workflow.connect([
         (inputnode, invert_t1w, [('t1_brain', 'in_file'),
                                  ('bold_ref', 'ref_file')]),
@@ -182,12 +180,9 @@ template [@fieldmapless3].
         (syn, unwarp_ref, [('forward_transforms', 'transforms')]),
         (inputnode, unwarp_ref, [('bold_ref', 'reference_image'),
                                  ('bold_ref', 'input_image')]),
-        (unwarp_ref, skullstrip_b0_wf, [
-            ('output_image', 'inputnode.in_file')]),
-        (unwarp_ref, outputnode, [('output_image', 'out_reference')]),
-        (skullstrip_b0_wf, outputnode, [
-            ('outputnode.skull_stripped_file', 'out_reference_brain'),
-            ('outputnode.mask_file', 'out_mask')]),
+        (unwarp_ref, outputnode, [
+            ('output_image', 'out_reference'),
+            ('output_image', 'out_reference_brain')])
     ])
 
     return workflow

--- a/qsiprep/workflows/fieldmap/unwarp.py
+++ b/qsiprep/workflows/fieldmap/unwarp.py
@@ -145,8 +145,6 @@ def init_sdc_unwarp_wf(omp_nthreads, fmap_demean, debug, name='sdc_unwarp_wf'):
 
     apply_fov_mask = pe.Node(fsl.ApplyMask(), name="apply_fov_mask")
 
-    enhance_and_skullstrip_b0 = init_enhance_and_skullstrip_dwi_wf(omp_nthreads=omp_nthreads)
-
     workflow.connect([
         (inputnode, fmap2ref_reg, [('fmap_ref', 'moving_image')]),
         (inputnode, fmap2ref_apply, [('in_reference', 'reference_image')]),
@@ -182,11 +180,9 @@ def init_sdc_unwarp_wf(omp_nthreads, fmap_demean, debug, name='sdc_unwarp_wf'):
         (fmap2ref_reg, fmap_fov2ref_apply, [('composite_transform', 'transforms')]),
         (fmap_fov2ref_apply, apply_fov_mask, [('output_image', 'mask_file')]),
         (unwarp_reference, apply_fov_mask, [('output_image', 'in_file')]),
-        (apply_fov_mask, enhance_and_skullstrip_b0, [('out_file', 'inputnode.in_file')]),
-        (apply_fov_mask, outputnode, [('out_file', 'out_reference')]),
-        (enhance_and_skullstrip_b0, outputnode, [
-            ('outputnode.mask_file', 'out_mask'),
-            ('outputnode.skull_stripped_file', 'out_reference_brain')]),
+        (apply_fov_mask, outputnode, [
+            ('out_file', 'out_reference'),
+            ('out_file', 'out_reference_brain')]),
         (jac_dfm, outputnode, [('jacobian_image', 'out_jacobian')]),
     ])
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -64,7 +64,7 @@ doc =
     packaging
     pydot >=1.2.3
     pydotplus
-    sphinx >=1.5.3
+    sphinx <=2.2.0
     sphinx-argparse
     sphinx_rtd_theme
 docs =


### PR DESCRIPTION
The workflow introduced in 0.7.2 worked in most cases, but was not robust enough to cover all cases reasonably. This PR adds in a preliminary b=0 to T1w registration and uses the T1 brain mask for the early stages in the pipeline that require a mask (ie motion correction)