### PR TITLE
[FIX] Deoblique T1w headers

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,8 @@
+0.8.0 (February 12, 2020)
+=========================
+
+ * Removes oblique angles from T1w headers to fix N4 bug (#103)
+
 0.7.2 (February 4, 2020)
 ========================
  * Fixed a bug in b=0 masking when images have high signal intensity in ventricles (#99)

--- a/qsiprep/interfaces/images.py
+++ b/qsiprep/interfaces/images.py
@@ -345,7 +345,8 @@ class Conform(SimpleInterface):
                 LOGGER.warning("Removing obliquity from image affine")
                 new_affine = reoriented.affine.copy()
                 new_affine[:, :-1] = 0
-                new_affine[(0, 1, 2), (0, 1, 2)] = reoriented.header.get_zooms()[:3]
+                new_affine[(0, 1, 2), (0, 1, 2)] = reoriented.header.get_zooms()[:3] \
+                    * np.sign(reoriented.affine[(0, 1, 2), (0, 1, 2)])
                 reoriented = nb.Nifti1Image(reoriented.get_fdata(), new_affine, reoriented.header)
 
         # Image may be reoriented, rescaled, and/or resized

--- a/qsiprep/interfaces/images.py
+++ b/qsiprep/interfaces/images.py
@@ -267,7 +267,7 @@ class ConformInputSpec(BaseInterfaceInputSpec):
                                 desc='Target zoom information')
     target_shape = traits.Tuple(traits.Int, traits.Int, traits.Int,
                                 desc='Target shape information')
-    deoublique_header = traits.Bool(False, usedfault=True)
+    deoblique_header = traits.Bool(False, usedfault=True)
 
 
 class ConformOutputSpec(TraitedSpec):

--- a/qsiprep/interfaces/images.py
+++ b/qsiprep/interfaces/images.py
@@ -267,6 +267,7 @@ class ConformInputSpec(BaseInterfaceInputSpec):
                                 desc='Target zoom information')
     target_shape = traits.Tuple(traits.Int, traits.Int, traits.Int,
                                 desc='Target shape information')
+    deoublique_header = traits.Bool(False, usedfault=True)
 
 
 class ConformOutputSpec(TraitedSpec):
@@ -337,6 +338,15 @@ class Conform(SimpleInterface):
             data = nli.resample_img(reoriented, target_affine, target_shape).get_data()
             conform_xfm = np.linalg.inv(reoriented.affine).dot(target_affine)
             reoriented = reoriented.__class__(data, target_affine, reoriented.header)
+
+        if self.inputs.deoblique_header:
+            is_oblique = np.any(np.abs(nb.affines.obliquity(reoriented.affine)) > 0)
+            if is_oblique:
+                LOGGER.warning("Removing obliquity from image affine")
+                new_affine = reoriented.affine.copy()
+                new_affine[:, :-1] = 0
+                new_affine[(0, 1, 2), (0, 1, 2)] = reoriented.header.get_zooms()[:3]
+                reoriented = nb.Nifti1Image(reoriented.get_fdata(), new_affine, reoriented.header)
 
         # Image may be reoriented, rescaled, and/or resized
         if reoriented is not orig_img:

--- a/qsiprep/interfaces/nilearn.py
+++ b/qsiprep/interfaces/nilearn.py
@@ -178,6 +178,7 @@ class EnhanceAndSkullstripB0(SimpleInterface):
                                                  cwd=runtime.cwd)
 
         # The brain mask should occupy a similar size as the t1 mask
+        input_img = load_img(self.inputs.b0_file)
         min_size = t1_brain_voxels * .7
         max_size = t1_brain_voxels * 1.3
         mask_voxels = mask_img.get_fdata().sum()

--- a/qsiprep/workflows/anatomical.py
+++ b/qsiprep/workflows/anatomical.py
@@ -533,7 +533,8 @@ A T1w-reference map was computed after registration of
 
     # 0. Reorient T1w image(s) to LPS and resample to common voxel space
     t1_template_dimensions = pe.Node(TemplateDimensions(), name='t1_template_dimensions')
-    t1_conform = pe.MapNode(Conform(), iterfield='in_file', name='t1_conform')
+    t1_conform = pe.MapNode(Conform(deoublique_header=True), iterfield='in_file',
+                            name='t1_conform')
 
     workflow.connect([
         (inputnode, t1_template_dimensions, [('t1w', 't1w_list')]),

--- a/qsiprep/workflows/anatomical.py
+++ b/qsiprep/workflows/anatomical.py
@@ -533,7 +533,7 @@ A T1w-reference map was computed after registration of
 
     # 0. Reorient T1w image(s) to LPS and resample to common voxel space
     t1_template_dimensions = pe.Node(TemplateDimensions(), name='t1_template_dimensions')
-    t1_conform = pe.MapNode(Conform(deoublique_header=True), iterfield='in_file',
+    t1_conform = pe.MapNode(Conform(deoblique_header=True), iterfield='in_file',
                             name='t1_conform')
 
     workflow.connect([

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ classifiers =
 [options]
 python_requires = >=3.5
 install_requires =
-    nibabel >=2.2.1
+    nibabel >=3.0.0
     indexed_gzip >=0.8.8
     nilearn !=0.5.0, !=0.5.1
     nipype <=1.1.9


### PR DESCRIPTION
There were "Images do not occupy the same physical space" errors in skull stripping that arose due to oblique affines in T1w images. Since these get put in ACPC space anyways, there is no issue with removing the oblique affine and replacing it with one that preserves the center and voxel sizes. Fixes #74.