### PR TITLE
[FIX] Rename workflows for HCP-style acquisitions

### DIFF
--- a/qsiprep/interfaces/fmap.py
+++ b/qsiprep/interfaces/fmap.py
@@ -1041,7 +1041,7 @@ def get_evenly_spaced_b0s(b0_indices, max_per_spec):
 
 
 def add_epi_fmaps_to_dwi_b0s(epi_fmaps, b0_threshold, max_per_spec, dwi_spec_lines, dwi_imain):
-    """Add additional images from EPI fieldmaps or distortion correction.
+    """Add additional images from EPI fieldmaps for distortion correction.
 
     In order to fill out the maximum number of images per distortion group, images
     from files in the fmap/ directory can be added to those already extracted from the
@@ -1092,7 +1092,7 @@ def add_epi_fmaps_to_dwi_b0s(epi_fmaps, b0_threshold, max_per_spec, dwi_spec_lin
 
 
 def eddy_inputs_from_dwi_files(origin_file_list, eddy_prefix):
-    unique_files = list(set(origin_file_list))
+    unique_files = sorted(set(origin_file_list))
     line_lookup = {}
     acqp_data = []
     for line_num, unique_dwi in enumerate(unique_files):

--- a/qsiprep/interfaces/images.py
+++ b/qsiprep/interfaces/images.py
@@ -10,10 +10,10 @@ Image tools interfaces
 """
 
 import os
+from textwrap import indent
 import numpy as np
 import nibabel as nb
 import nilearn.image as nli
-from textwrap import indent
 from dipy.io import read_bvals_bvecs
 from nipype import logging
 from nipype.utils.filemanip import fname_presuffix
@@ -24,6 +24,7 @@ from nipype.interfaces import fsl
 #    nii_ones_like, extract_wm, SignalExtraction, MatchHeader,
 #    FilledImageLike, DemeanImage, TemplateDimensions)
 from ..niworkflows.interfaces.images import ValidateImageInputSpec
+from .dwi_merge import MergeDWIs
 
 LOGGER = logging.getLogger('nipype.interface')
 
@@ -65,81 +66,6 @@ class SplitDWIs(SimpleInterface):
         self._results['b0_images'] = b0_paths
         self._results['b0_indices'] = b0_indices.tolist()
 
-        return runtime
-
-
-class ConcatRPESplitsInputSpec(BaseInterfaceInputSpec):
-    # Plus images
-    dwi_plus = InputMultiObject(File(exists=True), desc='plus dwi file')
-    bvec_plus = InputMultiObject(File(exists=True), desc='plus bvec file')
-    bval_plus = InputMultiObject(File(exists=True), desc='plus bval file')
-    noise_images_plus = InputMultiObject(File(exists=True), desc='plus_noise_images')
-    bias_images_plus = InputMultiObject(File(exists=True), desc='plus bias images')
-    denoising_confounds_plus = File(exists=True, desc='confounds csv from merging plus')
-    validation_reports_plus = InputMultiObject(File(exists=True))
-
-    # Minus images
-    dwi_minus = InputMultiObject(File(exists=True), desc='minus dwi file')
-    bvec_minus = InputMultiObject(File(exists=True), desc='minus bvec file')
-    bval_minus = InputMultiObject(File(exists=True), desc='minus bval file')
-    noise_images_minus = InputMultiObject(File(exists=True), desc='minus_noise_images')
-    bias_images_minus = InputMultiObject(File(exists=True), desc='minus bias images')
-    denoising_confounds_minus = File(exists=True, desc='confounds csv from merging minus')
-    validation_reports_minus = InputMultiObject(File(exists=True))
-
-
-class ConcatRPESplitsOutputSpec(TraitedSpec):
-    dwi_file = OutputMultiObject(File(exists=True), desc='plus and minus merged into on series')
-    bvec_file = OutputMultiObject(File(exists=True), desc='concatenated bvec file')
-    bval_file = OutputMultiObject(File(exists=True), desc='concatenated bval file')
-    bias_images = OutputMultiObject(File(exists=True), desc='bias field images')
-    noise_images = OutputMultiObject(File(exists=True), desc='noise level images')
-    b0_images = OutputMultiObject(File(exists=True), desc='just the b0s')
-    b0_indices = traits.List(desc='list of indices for each b0 image')
-    original_files = traits.List(desc='list of source series for each dwi')
-    sdc_method = traits.Str("PEB/PEPOLAR Series (phase-encoding based / PE-POLARity)")
-    denoising_confounds = File(exists=True, desc='plus and minus confounds merged')
-    validation_reports = OutputMultiObject(File(exists=True))
-
-
-class ConcatRPESplits(SimpleInterface):
-    """Combine the outputs from the RPE series workflow into a SplitDWI-like object.
-
-    Plus series goes first, indices are adjusted for minus to be globally correct.
-    head motion affines are combined with to-ref affines and stored in dwi_to_ref_affines.
-    """
-
-    input_spec = ConcatRPESplitsInputSpec
-    output_spec = ConcatRPESplitsOutputSpec
-
-    def _run_interface(self, runtime):
-
-        plus_images = self.inputs.dwi_plus
-        plus_bvecs = self.inputs.bvec_plus
-        plus_bvals = self.inputs.bval_plus
-        plus_b0_images = self.inputs.b0_images_plus
-        plus_b0_indices = self.inputs.b0_indices_plus
-        plus_orig_files = self.inputs.original_images_plus
-        num_plus = len(plus_images)
-
-        minus_images = self.inputs.dwi_minus
-        minus_bvecs = self.inputs.bvec_minus
-        minus_bvals = self.inputs.bval_minus
-        minus_b0_images = self.inputs.b0_images_minus
-        minus_b0_indices = self.inputs.b0_indices_minus
-        minus_orig_files = self.inputs.original_images_minus
-
-        self._results['dwi_files'] = plus_images + minus_images
-        self._results['bval_files'] = plus_bvals + minus_bvals
-        self._results['bvec_files'] = plus_bvecs + minus_bvecs
-        self._results['b0_images'] = plus_b0_images + minus_b0_images
-        self._results['b0_indices'] = plus_b0_indices + [
-            num_plus + idx for idx in minus_b0_indices]
-        self._results['original_files'] = _flatten(plus_orig_files) \
-            + _flatten(minus_orig_files)
-        self._results['validation_reports'] = self.inputs.validation_reports_plus \
-            + self.inputs.validation_reports_minus
-        self._results['sdc_method'] = "PEB/PEPOLAR Series (TOPUP)"
         return runtime
 
 

--- a/qsiprep/utils/grouping.py
+++ b/qsiprep/utils/grouping.py
@@ -937,15 +937,18 @@ def get_concatenated_bids_name(dwi_group):
 
 
 def _get_common_bids_fields(fnames):
-    bids_keys = defaultdict(list)
+    bids_keys = defaultdict(set)
     for fname in fnames:
         basename = split_filename(fname)[1]
-        for key, value in [token.split("-") for token in basename.split("_")]:
-            bids_keys[key].append(value)
+        for token in basename.split("_"):
+            parts = token.split("-")
+            if len(parts) == 2:
+                key, value = parts
+                bids_keys[key].update((value,))
 
     # Find all the keys with a single unique value
     common_bids = []
     for key in ['sub', 'ses', 'acq', 'dir', 'run']:
         if len(bids_keys[key]) == 1:
-            common_bids.append(key + bids_keys[key][0])
+            common_bids.append(key + "-" + bids_keys[key].pop())
     return "_".join(common_bids)

--- a/qsiprep/utils/grouping.py
+++ b/qsiprep/utils/grouping.py
@@ -922,13 +922,7 @@ def get_concatenated_bids_name(dwi_group):
     """
     # If a single file, use its name, otherwise use the common prefix
     if len(dwi_group) > 1:
-        no_runs = []
-        for dwi in dwi_group:
-            no_runs.append(
-                "_".join([part for part in dwi.split("_")
-                          if not part.startswith("run")]))
-        input_fname = os.path.commonprefix(no_runs)
-        fname = split_filename(input_fname)[1]
+        fname = _get_common_bids_fields(dwi_group)
         parts = fname.split('_')
         full_parts = [part for part in parts if not part.endswith('-')]
         fname = '_'.join(full_parts)
@@ -940,3 +934,18 @@ def get_concatenated_bids_name(dwi_group):
         fname = fname[:-4]
 
     return fname.replace(".", "").replace(" ", "")
+
+
+def _get_common_bids_fields(fnames):
+    bids_keys = defaultdict(list)
+    for fname in fnames:
+        basename = split_filename(fname)[1]
+        for key, value in [token.split("-") for token in basename.split("_")]:
+            bids_keys[key].append(value)
+
+    # Find all the keys with a single unique value
+    common_bids = []
+    for key in ['sub', 'ses', 'acq', 'dir', 'run']:
+        if len(bids_keys[key]) == 1:
+            common_bids.append(key + bids_keys[key][0])
+    return "_".join(common_bids)

--- a/qsiprep/workflows/dwi/pre_hmc.py
+++ b/qsiprep/workflows/dwi/pre_hmc.py
@@ -192,7 +192,7 @@ def init_dwi_pre_hmc_wf(scan_groups,
             (merge_minus, pm_noise_images, [
                 ('outputnode.noise_images', 'in2')]),
             (merge_minus, pm_denoising_confounds, [
-                ('outputnode.denoising_confounds', 'denoising_con')]),
+                ('outputnode.denoising_confounds', 'in2')]),
             (merge_minus, pm_validation, [
                 ('outputnode.validation_reports', 'in2')]),
 
@@ -210,7 +210,7 @@ def init_dwi_pre_hmc_wf(scan_groups,
                 ('original_images', 'original_files'),
                 ('merged_denoising_confounds', 'denoising_confounds')]),
             (pm_validation, outputnode, [
-                ('validation_reports', 'validation_reports')]),
+                ('out', 'validation_reports')]),
             (pm_noise_images, outputnode, [
                 ('out', 'noise_images')]),
             (pm_bias, outputnode, [

--- a/qsiprep/workflows/dwi/pre_hmc.py
+++ b/qsiprep/workflows/dwi/pre_hmc.py
@@ -11,7 +11,7 @@ from nipype import logging
 from nipype.pipeline import engine as pe
 from nipype.interfaces import utility as niu
 
-from ...interfaces.images import ConcatRPESplits
+from ...interfaces.dwi_merge import MergeDWIs
 from ...engine import Workflow
 
 # dwi workflows
@@ -145,38 +145,79 @@ def init_dwi_pre_hmc_wf(scan_groups,
                                                 name="merge_minus")
 
         # Combine the original images from the splits into one 4D series + bvals/bvecs
-        concat_rpe_splits = pe.Node(ConcatRPESplits(), name="concat_rpe_splits")
+        pm_validation = pe.Node(niu.Merge(2), name='pm_validation')
+        pm_dwis = pe.Node(niu.Merge(2), name='pm_dwis')
+        pm_bids_dwis = pe.Node(niu.Merge(2), name='pm_bids_dwis')
+        pm_bvals = pe.Node(niu.Merge(2), name='pm_bvals')
+        pm_bvecs = pe.Node(niu.Merge(2), name='pm_bvecs')
+        pm_bias = pe.Node(niu.Merge(2), name='pm_bias')
+        pm_noise_images = pe.Node(niu.Merge(2), name='pm_noise')
+        pm_denoising_confounds = pe.Node(niu.Merge(2), name='pm_denoising_confounds')
+        rpe_concat = pe.Node(
+            MergeDWIs(harmonize_b0_intensities=not no_b0_harmonization,
+                      b0_threshold=b0_threshold),
+            name='rpe_concat')
         qc_wf = init_modelfree_qc_wf(dwi_files=plus_files + minus_files)
 
         workflow.connect([
-            # Merge, denoise, combine
-            (merge_plus, concat_rpe_splits, [
-                ('outputnode.merged_image', 'dwi_plus'),
-                ('outputnode.merged_bval', 'bval_plus'),
-                ('outputnode.merged_bvec', 'bvec_plus'),
-                ('outputnode.bias_images', 'bias_images_plus'),
-                ('outputnode.noise_images', 'noise_images_plus'),
-                ('outputnode.denoising_confounds', 'denoising_confounds_plus')]),
-            (merge_minus, concat_rpe_splits, [
-                ('outputnode.merged_image', 'dwi_minus'),
-                ('outputnode.merged_bval', 'bval_minus'),
-                ('outputnode.merged_bvec', 'bvec_minus'),
-                ('outputnode.bias_images', 'bias_images_minus'),
-                ('outputnode.noise_images', 'noise_images_minus'),
-                ('outputnode.denoising_confounds', 'denoising_confounds_minus')]),
+            # combine PE+
+            (merge_plus, pm_dwis, [
+                ('outputnode.merged_image', 'in1')]),
+            (merge_plus, pm_bids_dwis, [
+                ('outputnode.original_files', 'in1')]),
+            (merge_plus, pm_bvals, [
+                ('outputnode.merged_bval', 'in1')]),
+            (merge_plus, pm_bvecs, [
+                ('outputnode.merged_bvec', 'in1')]),
+            (merge_plus, pm_bias, [
+                ('outputnode.bias_images', 'in1')]),
+            (merge_plus, pm_noise_images, [
+                ('outputnode.noise_images', 'in1')]),
+            (merge_plus, pm_denoising_confounds, [
+                ('outputnode.denoising_confounds', 'in1')]),
+            (merge_plus, pm_validation, [
+                ('outputnode.validation_reports', 'in1')]),
+
+            # combine PE-
+            (merge_minus, pm_dwis, [
+                ('outputnode.merged_image', 'in2')]),
+            (merge_minus, pm_bids_dwis, [
+                ('outputnode.original_files', 'in2')]),
+            (merge_minus, pm_bvals, [
+                ('outputnode.merged_bval', 'in2')]),
+            (merge_minus, pm_bvecs, [
+                ('outputnode.merged_bvec', 'in2')]),
+            (merge_minus, pm_bias, [
+                ('outputnode.bias_images', 'in2')]),
+            (merge_minus, pm_noise_images, [
+                ('outputnode.noise_images', 'in2')]),
+            (merge_minus, pm_denoising_confounds, [
+                ('outputnode.denoising_confounds', 'denoising_con')]),
+            (merge_minus, pm_validation, [
+                ('outputnode.validation_reports', 'in2')]),
+
+            (pm_dwis, rpe_concat, [('out', 'dwi_files')]),
+            (pm_bids_dwis, rpe_concat, [('out', 'bids_dwi_files')]),
+            (pm_bvals, rpe_concat, [('out', 'bval_files')]),
+            (pm_bvecs, rpe_concat, [('out', 'bvec_files')]),
+            (pm_denoising_confounds, rpe_concat, [('out', 'denoising_confounds')]),
+
             # Connect to the outputnode
-            (concat_rpe_splits, outputnode, [
-                ('dwi_file', 'dwi_file'),
-                ('bval_file', 'bval_file'),
-                ('bvec_file', 'bvec_file'),
-                ('original_files', 'original_files'),
-                ('denoising_confounds', 'denoising_confounds'),
-                ('validation_reports', 'validation_reports'),
-                ('noise_images', 'noise_images'),
-                ('bias_images', 'bias_images')]),
-            (concat_rpe_splits, qc_wf, [
-                ('bval_file', 'inputnode.bval_file'),
-                ('bvec_file', 'inputnode.bvec_file')]),
+            (rpe_concat, outputnode, [
+                ('out_dwi', 'dwi_file'),
+                ('out_bval', 'bval_file'),
+                ('out_bvec', 'bvec_file'),
+                ('original_images', 'original_files'),
+                ('merged_denoising_confounds', 'denoising_confounds')]),
+            (pm_validation, outputnode, [
+                ('validation_reports', 'validation_reports')]),
+            (pm_noise_images, outputnode, [
+                ('out', 'noise_images')]),
+            (pm_bias, outputnode, [
+                ('out', 'bias_images')]),
+            (rpe_concat, qc_wf, [
+                ('out_bval', 'inputnode.bval_file'),
+                ('out_bvec', 'inputnode.bvec_file')]),
             (qc_wf, outputnode, [('outputnode.qc_summary', 'qc_file')])])
         workflow.__postdesc__ = "Both groups were then merged into a single file, as required " \
                                 "for the FSL workflows. "


### PR DESCRIPTION
This includes multiple fixes for merging HCP-style scans

 * Renames subworkflows to include `dir_`
 * Re-purpose MergeDWIs to also merge across PE directions
 * Replace ConcateRPESplits with a NiPype workflow