### PR TITLE
[ENH] Enable HCP-style polarity-pair image averaging

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,9 @@
+0.9.0beta1 (June 17, 2020)
+==========================
+
+ * Adds support for HCP lifespan sequences
+ * Introduces --distortion-group-merge option for combining paired scans
+
 0.8.0 (February 12, 2020)
 =========================
 
@@ -5,6 +11,7 @@
 
 0.7.2 (February 4, 2020)
 ========================
+
  * Fixed a bug in b=0 masking when images have high signal intensity in ventricles (#99)
 
 0.7.1 (January 29, 2020)

--- a/docs/preprocessing.rst
+++ b/docs/preprocessing.rst
@@ -56,6 +56,8 @@ The are three kinds of SDC available in qsiprep:
      The reverse phase encoding direction scan can come from the fieldmaps directory
      or the dwi directory.
 
+     1a. If using ``eddy``, then ``TOPUP`` is used for this correction.
+
   2. :ref:`sdc_phasediff`: Use a B0map sequence that includes at lease one magnitude
      image and two phase images or a phasediff image.
 
@@ -68,6 +70,22 @@ The are three kinds of SDC available in qsiprep:
 
 ``qsiprep`` determines if a fieldmap should be used based on the ``"IntendedFor"``
 fields in the JSON sidecars in the ``fmap/`` directory.
+
+Preprocessing HCP-style
+^^^^^^^^^^^^^^^^^^^^^^^
+
+QSIPrep can be configured to produce a very similar pipeline to the HCP dMRI pipelines.
+HCP and HCP-Lifespan scans acquire complete multi-shell sequences in opposing phase
+encoding directions, making them a special case where :ref:`sdc_pepolar` are used
+and the corrected images from both PE directions are averaged at the end. To produce
+output from ``qsiprep`` that is directly comparable to the HCP dMRI pipeline you
+will want to include::
+
+  --distortion-group-merge average \
+  --combine-all-dwis \
+
+If you want to disable the image pair averaging and get a result with twice as
+many images, you can substitute ``average`` with ``concat``.
 
 
 .. _outputs:

--- a/qsiprep/cli/run.py
+++ b/qsiprep/cli/run.py
@@ -204,6 +204,18 @@ def get_parser():
         help='combine dwis from across multiple runs for motion correction '
         'and reconstruction.')
     g_conf.add_argument(
+        '--distortion-group-merge', '--distortion_group_merge',
+        action='store',
+        choices=['concat', 'average', 'none'],
+        default='none',
+        help='How to combine images across distorted groups.\n'
+        ' - concatenate: append images in the 4th dimension\n '
+        ' - average: if a whole sequence was duplicated in both PE\n'
+        '            directions, average the corrected images of the same\n'
+        '            q-space coordinate\n'
+        ' - none: Default. Keep distorted groups separate'
+    )
+    g_conf.add_argument(
         '--write-local-bvecs', '--write_local_bvecs',
         action='store_true',
         default=False,
@@ -639,7 +651,7 @@ def main():
     except Exception as e:
         if not opts.notrack:
             from ..utils.sentry import process_crashfile
-            crashfolders = [output_dir / 'qsirecon' / 'sub-{}'.format(s) / 'log' / run_uuid
+            crashfolders = [Path(output_dir) / 'qsirecon' / 'sub-{}'.format(s) / 'log' / run_uuid
                             for s in subject_list]
             for crashfolder in crashfolders:
                 for crashfile in crashfolder.glob('crash*.*'):
@@ -841,6 +853,7 @@ def build_qsiprep_workflow(opts, retval):
         longitudinal=opts.longitudinal,
         b0_threshold=opts.b0_threshold,
         combine_all_dwis=opts.combine_all_dwis,
+        distortion_group_merge=opts.distortion_group_merge,
         dwi_denoise_window=opts.dwi_denoise_window,
         unringing_method=opts.unringing_method,
         dwi_no_biascorr=opts.dwi_no_biascorr,

--- a/qsiprep/cli/run.py
+++ b/qsiprep/cli/run.py
@@ -180,7 +180,7 @@ def get_parser():
         help='window size in voxels for ``dwidenoise``. Must be odd (default: 5). '
              'If 0, ``dwidwenoise`` will not be run')
     g_conf.add_argument(
-        '--unringing-method', '--unringing-method',
+        '--unringing-method', '--unringing_method',
         action='store',
         choices=['none', 'mrdegibbs'],
         help='Method for Gibbs-ringing removal.\n - none: no action\n - mrdegibbs: '

--- a/qsiprep/interfaces/dwi_merge.py
+++ b/qsiprep/interfaces/dwi_merge.py
@@ -125,7 +125,7 @@ class AveragePEPairsInputSpec(MergeDWIsInputSpec):
 
 
 class AveragePEPairsOutputSpec(MergeDWIsOutputSpec):
-    pass
+    merged_raw_concatenated = File(exists=True)
 
 
 class AveragePEPairs(SimpleInterface):
@@ -133,6 +133,7 @@ class AveragePEPairs(SimpleInterface):
     output_spec = AveragePEPairsOutputSpec
 
     def _run_interface(self, runtime):
+        assert 0
         return runtime
 
 

--- a/qsiprep/interfaces/dwi_merge.py
+++ b/qsiprep/interfaces/dwi_merge.py
@@ -26,7 +26,9 @@ class MergeDWIsInputSpec(BaseInterfaceInputSpec):
     harmonize_b0_intensities = traits.Bool(True, usedefault=True,
                                            desc='Force scans to have the same mean b=0 intensity')
     raw_concatenated_files = InputMultiObject(
-        File(), mandatory=True, desc='list of raw concatenated images')
+        File(), mandatory=False, desc='list of raw concatenated images')
+    b0_refs = InputMultiObject(
+        File(), mandatory=False, desc='list of b=0 reference images')
 
 
 class MergeDWIsOutputSpec(TraitedSpec):
@@ -36,6 +38,7 @@ class MergeDWIsOutputSpec(TraitedSpec):
     original_images = traits.List()
     merged_metadata = traits.Dict()
     merged_denoising_confounds = File(exists=True)
+    merged_b0_ref = File(exists=True)
 
 
 class MergeDWIs(SimpleInterface):
@@ -73,7 +76,7 @@ class MergeDWIs(SimpleInterface):
         confounds_df['original_bx'] = all_bvecs[0]
         confounds_df['original_by'] = all_bvecs[1]
         confounds_df['original_bz'] = all_bvecs[2]
-        confounds_df = confounds_df.loc[:,~confounds_df.columns.duplicated()]
+        confounds_df = confounds_df.loc[:, ~confounds_df.columns.duplicated()]
 
         # Concatenate the gradient information
         if num_dwis > 1:

--- a/qsiprep/interfaces/dwi_merge.py
+++ b/qsiprep/interfaces/dwi_merge.py
@@ -150,14 +150,14 @@ class AveragePEPairs(SimpleInterface):
         original_bvecs = combined_bvec_array(self.inputs.original_bvec_files)
         rotated_bvecs = combined_bvec_array(self.inputs.bvec_files)
         bvals = combined_bval_array(self.inputs.bval_files)
-        
+
         # Find which images should be averaged together in the output
         image_pairs, averaged_raw_bvec = find_image_pairs(original_bvecs, bvals, assignments)
         combined_images, combined_raw_images, combined_bvals, combined_bvecs, error_report = \
-		average_image_pairs(image_pairs, self.inputs.dwi_files, rotated_bvecs,
-                                    bvals, self.inputs.denoising_confounds,
-                                    self.inputs.raw_concatenated_files,
-                                    verbose=self.inputs.verbose)	
+            average_image_pairs(image_pairs, self.inputs.dwi_files, rotated_bvecs,
+                                bvals, self.inputs.denoising_confounds,
+                                self.inputs.raw_concatenated_files,
+                                verbose=self.inputs.verbose)
 
         # Save the averaged outputs
         out_dwi_path = op.join(runtime.cwd, "averaged_pairs.nii.gz")
@@ -182,7 +182,7 @@ class AveragePEPairs(SimpleInterface):
 
         # Make a new b=0 template
         b0_indices = np.flatnonzero(bvals < self.inputs.b0_threshold)
-        b0_ref = ants.AverageImages(dimension=3, normalize=True, 
+        b0_ref = ants.AverageImages(dimension=3, normalize=True,
                                     images=[self.inputs.dwi_files[idx] for idx in b0_indices])
         result = b0_ref.run()
         self._results['merged_b0_ref'] = result.outputs.output_average_image
@@ -202,7 +202,7 @@ def find_image_pairs(original_bvecs, bvals, assignments):
     }
     group2 = {
         'bvals': bvals[group2_mask],
-        'original_bvecs': original_bvecs[:, group2_mask], 
+        'original_bvecs': original_bvecs[:, group2_mask],
         'indices': image_nums[group2_mask]
     }
 
@@ -284,13 +284,13 @@ def average_image_pairs(image_pairs, image_paths, rotated_bvecs, bvals, confound
                      new_bvec[1], new_bvec[2]))
 
     averaged_confounds = pd.DataFrame(merged_confounds)
-    return concat_imgs(averaged_images), concat_imgs(raw_averaged_images), np.array(merged_bvals), \
-        np.array(new_bvecs), averaged_confounds
+    return concat_imgs(averaged_images), concat_imgs(raw_averaged_images), \
+        np.array(merged_bvals), np.array(new_bvecs), averaged_confounds
 
 
 def average_bvec(bvec1, bvec2):
     bvec_diff = angle_between(bvec1, bvec2)
-    
+
     mean_bvec_plus = (bvec1 + bvec2) / 2.
     mean_bvec_plus = mean_bvec_plus / np.linalg.norm(mean_bvec_plus)
     mean_bvec_minus = (bvec1 - bvec2) / 2.

--- a/qsiprep/interfaces/images.py
+++ b/qsiprep/interfaces/images.py
@@ -24,7 +24,6 @@ from nipype.interfaces import fsl
 #    nii_ones_like, extract_wm, SignalExtraction, MatchHeader,
 #    FilledImageLike, DemeanImage, TemplateDimensions)
 from ..niworkflows.interfaces.images import ValidateImageInputSpec
-from .dwi_merge import MergeDWIs
 
 LOGGER = logging.getLogger('nipype.interface')
 

--- a/qsiprep/interfaces/reports.py
+++ b/qsiprep/interfaces/reports.py
@@ -624,22 +624,19 @@ def calculate_motion_summary(confounds_tsv):
     # Combine the FDs from both PE directions
     # both_fd = np.column_stack([m1, m2])
     # framewise_disp = both_fd[np.nanargmax(np.abs(both_fd), axis=1)]
-   
     def compare_series(key_name, comparator):
         m1 = motion1[key_name][0]
         m2 = motion2[key_name][0]
         return [comparator(m1, m2)]
 
     return {
-        "mean_fd": compare_series("mean_fd", lambda a,b: (a + b) / 2),
+        "mean_fd": compare_series("mean_fd", lambda a, b: (a + b) / 2),
         "max_fd": compare_series("max_fd", max),
         "max_rotation": compare_series("max_rotation", max),
         "max_translation": compare_series("max_translation", max),
-        "max_rel_rotation": compare_series("max_rel_rotation", max) ,
+        "max_rel_rotation": compare_series("max_rel_rotation", max),
         "max_rel_translation": compare_series("max_rel_translation", max)
     }
-
-    return motion_summary
 
 
 class _InteractiveReportInputSpec(TraitedSpec):

--- a/qsiprep/interfaces/utils.py
+++ b/qsiprep/interfaces/utils.py
@@ -291,6 +291,7 @@ class TestInput(SimpleInterface):
     def _run_interface(self, runtime):
         return runtime
 
+
 class JoinTSVColumnsInputSpec(BaseInterfaceInputSpec):
     in_file = File(exists=True, mandatory=True, desc='input file')
     join_file = File(exists=True, mandatory=True, desc='file to be adjoined')

--- a/qsiprep/interfaces/utils.py
+++ b/qsiprep/interfaces/utils.py
@@ -281,6 +281,16 @@ class AddTSVHeader(SimpleInterface):
         return runtime
 
 
+class TestInputInputSpec(BaseInterfaceInputSpec):
+    test1 = traits.Any()
+
+
+class TestInput(SimpleInterface):
+    input_spec = TestInputInputSpec
+
+    def _run_interface(self, runtime):
+        return runtime
+
 class JoinTSVColumnsInputSpec(BaseInterfaceInputSpec):
     in_file = File(exists=True, mandatory=True, desc='input file')
     join_file = File(exists=True, mandatory=True, desc='file to be adjoined')

--- a/qsiprep/utils/grouping.py
+++ b/qsiprep/utils/grouping.py
@@ -902,7 +902,7 @@ def group_for_concatenation(all_dwi_fmap_groups):
     for _, dwi_fmap_groups in session_groups.items():
         all_images = []
         for group in dwi_fmap_groups:
-            all_images.extend(group['dwi_files'])
+            all_images.extend(group['dwi_series'])
         group_name = get_concatenated_bids_name(all_images)
         # Add separate groups for non-compatible fieldmaps
         for group in dwi_fmap_groups:

--- a/qsiprep/workflows/base.py
+++ b/qsiprep/workflows/base.py
@@ -592,6 +592,13 @@ to workflows in *qsiprep*'s documentation]\
         for merged_group in merged_group_names:
             merging_group_workflows[merged_group] = init_distortion_group_merge_wf(
                 merging_strategy=distortion_group_merge,
+                harmonize_b0_intensities=not no_b0_harmonization,
+                b0_threshold=b0_threshold,
+                template=template,
+                output_dir=output_dir,
+                output_prefix=merged_group,
+                source_file='',
+                shoreline_iters=shoreline_iters,
                 hmc_model=hmc_model,
                 inputs_list=merged_to_subgroups[merged_group],
                 omp_nthreads=omp_nthreads,
@@ -615,7 +622,6 @@ to workflows in *qsiprep*'s documentation]\
         omp_nthreads=omp_nthreads,
         t1w_source_file=fix_multi_T1w_source_name(subject_data['t1w']),
         reportlets_dir=reportlets_dir,
-        template=template,
         num_iterations=intramodal_template_iters,
         transform=intramodal_template_transform,
         inputs_list=sorted(outputs_to_files.keys()),
@@ -793,24 +799,29 @@ to workflows in *qsiprep*'s documentation]\
 
         if merging_distortion_groups:
             image_name = 'inputnode.{name}_image'.format(name=output_wfname)
-            raw_concatenated_image_name = 'inputnode.{name}_raw_concatenated_image'.format(
-                name=output_wfname)
             bval_name = 'inputnode.{name}_bval'.format(name=output_wfname)
             bvec_name = 'inputnode.{name}_bvec'.format(name=output_wfname)
             original_bvec_name = 'inputnode.{name}_original_bvec'.format(
                 name=output_wfname)
             original_bids_name = 'inputnode.{name}_original_image'.format(
                 name=output_wfname)
+            raw_concatenated_image_name = 'inputnode.{name}_raw_concatenated_image'.format(
+                name=output_wfname)
+            confounds_name = 'inputnode.{name}_confounds'.format(name=output_wfname)
+            b0_ref_name = 'inputnode.{name}_b0_ref'.format(name=output_wfname)
             final_merge_wf = merging_group_workflows[concatenation_scheme[output_fname]]
             workflow.connect([
                 (dwi_finalize_wf, final_merge_wf, [
                     ('outputnode.bvals_t1', bval_name),
                     ('outputnode.bvecs_t1', bvec_name),
-                    ('outputnode.dwi_t1', image_name)]),
+                    ('outputnode.dwi_t1', image_name),
+                    ('outputnode.t1_b0_ref', b0_ref_name),
+                    ]),
                 (dwi_preproc_wf, final_merge_wf, [
                     ('outputnode.raw_concatenated', raw_concatenated_image_name),
                     ('outputnode.original_bvecs', original_bvec_name),
-                    ('outputnode.original_files', original_bids_name)])
+                    ('outputnode.original_files', original_bids_name),
+                    ('outputnode.confounds', confounds_name)])
             ])
 
     return workflow

--- a/qsiprep/workflows/base.py
+++ b/qsiprep/workflows/base.py
@@ -610,8 +610,6 @@ to workflows in *qsiprep*'s documentation]\
                     ('outputnode.t1_mask', 'inputnode.t1_mask'),
                     ('outputnode.t1_seg', 'inputnode.t1_seg')])
             ])
-                        
-
 
     outputs_to_files = {dwi_group['concatenated_bids_name']: dwi_group
                         for dwi_group in dwi_fmap_groups}

--- a/qsiprep/workflows/base.py
+++ b/qsiprep/workflows/base.py
@@ -597,13 +597,21 @@ to workflows in *qsiprep*'s documentation]\
                 template=template,
                 output_dir=output_dir,
                 output_prefix=merged_group,
-                source_file='',
+                source_file=merged_group + '_dwi.nii.gz',
                 shoreline_iters=shoreline_iters,
                 hmc_model=hmc_model,
                 inputs_list=merged_to_subgroups[merged_group],
                 omp_nthreads=omp_nthreads,
                 reportlets_dir=reportlets_dir,
                 name=merged_group.replace('-', '_') + "_final_merge_wf")
+            workflow.connect([
+                (anat_preproc_wf, merging_group_workflows[merged_group], [
+                    ('outputnode.t1_brain', 'inputnode.t1_brain'),
+                    ('outputnode.t1_mask', 'inputnode.t1_mask'),
+                    ('outputnode.t1_seg', 'inputnode.t1_seg')])
+            ])
+                        
+
 
     outputs_to_files = {dwi_group['concatenated_bids_name']: dwi_group
                         for dwi_group in dwi_fmap_groups}
@@ -809,6 +817,7 @@ to workflows in *qsiprep*'s documentation]\
                 name=output_wfname)
             confounds_name = 'inputnode.{name}_confounds'.format(name=output_wfname)
             b0_ref_name = 'inputnode.{name}_b0_ref'.format(name=output_wfname)
+            cnr_name = 'inputnode.{name}_cnr'.format(name=output_wfname)
             final_merge_wf = merging_group_workflows[concatenation_scheme[output_fname]]
             workflow.connect([
                 (dwi_finalize_wf, final_merge_wf, [
@@ -816,6 +825,7 @@ to workflows in *qsiprep*'s documentation]\
                     ('outputnode.bvecs_t1', bvec_name),
                     ('outputnode.dwi_t1', image_name),
                     ('outputnode.t1_b0_ref', b0_ref_name),
+                    ('outputnode.cnr_map_t1', cnr_name)
                     ]),
                 (dwi_preproc_wf, final_merge_wf, [
                     ('outputnode.raw_concatenated', raw_concatenated_image_name),

--- a/qsiprep/workflows/base.py
+++ b/qsiprep/workflows/base.py
@@ -615,6 +615,7 @@ to workflows in *qsiprep*'s documentation]\
         omp_nthreads=omp_nthreads,
         t1w_source_file=fix_multi_T1w_source_name(subject_data['t1w']),
         reportlets_dir=reportlets_dir,
+        template=template,
         num_iterations=intramodal_template_iters,
         transform=intramodal_template_transform,
         inputs_list=sorted(outputs_to_files.keys()),

--- a/qsiprep/workflows/dwi/base.py
+++ b/qsiprep/workflows/dwi/base.py
@@ -310,7 +310,8 @@ def init_dwi_preproc_wf(scan_groups,
             'confounds', 'hmc_optimization_data', 'itk_b0_to_t1', 'noise_images', 'bias_images',
             'dwi_files', 'cnr_map', 'bval_files', 'bvec_files', 'b0_ref_image', 'b0_indices',
             'dwi_mask', 'hmc_xforms', 'fieldwarps', 'sbref_file', 'original_files',
-            'raw_qc_file', 'coreg_score', 'raw_concatenated', 'carpetplot_data']),
+            'original_bvecs', 'raw_qc_file', 'coreg_score', 'raw_concatenated',
+            'carpetplot_data']),
         name='outputnode')
     workflow.__desc__ = """
 
@@ -381,6 +382,7 @@ Diffusion data preprocessing
         (pre_hmc_wf, outputnode, [
             ('outputnode.qc_file', 'raw_qc_file'),
             ('outputnode.original_files', 'original_files'),
+            ('outputnode.bvec_file', 'original_bvecs'),
             ('outputnode.bias_images', 'bias_images'),
             ('outputnode.noise_images', 'noise_images'),
             ('outputnode.raw_concatenated', 'raw_concatenated')])

--- a/qsiprep/workflows/dwi/base.py
+++ b/qsiprep/workflows/dwi/base.py
@@ -15,6 +15,7 @@ from ...interfaces import DerivativesDataSink
 
 from ...interfaces.reports import DiffusionSummary
 from ...interfaces.confounds import DMRISummary
+from ...interfaces.utils import TestInput
 from ...engine import Workflow
 
 # dwi workflows
@@ -331,6 +332,7 @@ Diffusion data preprocessing
                                      low_mem=low_mem,
                                      denoise_before_combining=denoise_before_combining,
                                      omp_nthreads=omp_nthreads)
+    test_pre_hmc_connect = pe.Node(TestInput(), name='test_pre_hmc_connect')
 
     if hmc_model in ('none', '3dSHORE'):
         if not hmc_model == 'none' and shoreline_iters < 1:
@@ -385,7 +387,8 @@ Diffusion data preprocessing
             ('outputnode.bvec_file', 'original_bvecs'),
             ('outputnode.bias_images', 'bias_images'),
             ('outputnode.noise_images', 'noise_images'),
-            ('outputnode.raw_concatenated', 'raw_concatenated')])
+            ('outputnode.raw_concatenated', 'raw_concatenated')]),
+        (pre_hmc_wf, test_pre_hmc_connect, [('outputnode.raw_concatenated', 'test1')])
     ])
 
     # calculate dwi registration to T1w

--- a/qsiprep/workflows/dwi/distortion_group_merge.py
+++ b/qsiprep/workflows/dwi/distortion_group_merge.py
@@ -85,8 +85,7 @@ def init_distortion_group_merge_wf(merging_strategy, inputs_list, hmc_model, rep
             fields=["merged_image", "merged_bval", "merged_bvec", "merged_qc", "merged_cnr_map"
                     'dwi_mask_t1', 'cnr_map_t1', 'merged_bval', 'bvecs_t1',
                     'local_bvecs_t1', 't1_b0_ref', 'confounds',
-                    'gradient_table_t1', 'hmc_optimization_data'
-        ]),
+                    'gradient_table_t1', 'hmc_optimization_data']),
         name='outputnode')
 
     num_inputs = len(input_names)
@@ -171,9 +170,7 @@ def init_distortion_group_merge_wf(merging_strategy, inputs_list, hmc_model, rep
         hmc_model=hmc_model,
         shoreline_iters=shoreline_iters)
 
-
     workflow.connect([
-
         # Mask the new b=0 reference
         (distortion_merger, b0_ref_wf, [
             ('merged_b0_ref', 'inputnode.b0_template')]),
@@ -200,7 +197,7 @@ def init_distortion_group_merge_wf(merging_strategy, inputs_list, hmc_model, rep
         (processed_qc_wf, series_qc, [
             ('outputnode.qc_summary', 't1_qc')]),
         (b0_ref_wf, t1_dice_calc, [
-             ('outputnode.dwi_mask', 'inputnode.dwi_mask')]),
+            ('outputnode.dwi_mask', 'inputnode.dwi_mask')]),
         (inputnode, t1_dice_calc, [
             ('t1_mask', 'inputnode.anatomical_mask')]),
         (t1_dice_calc, series_qc, [('outputnode.dice_score', 't1_dice_score')]),
@@ -212,31 +209,30 @@ def init_distortion_group_merge_wf(merging_strategy, inputs_list, hmc_model, rep
             ('out_dwi', 'merged_image'),
             ('merged_denoising_confounds', 'confounds')
         ]),
-        
+
         # Report the merged gradients
         (outputnode, gradient_plot, [('bvecs_t1', 'final_bvec_file')]),
         (distortion_merger, gradient_plot, [
-             ('out_bvec', 'orig_bvec_files'),
-             ('out_bval', 'orig_bval_files'),
-             ('original_images', 'source_files')]),
+            ('out_bvec', 'orig_bvec_files'),
+            ('out_bval', 'orig_bval_files'),
+            ('original_images', 'source_files')]),
         (gradient_plot, ds_report_gradients, [('plot_file', 'in_file')]),
         (distortion_merger, gtab_t1, [('out_bval', 'bval_file'),
                                       ('out_bvec', 'bvec_file')]),
         (gtab_t1, outputnode, [('gradient_file', 'gradient_table_t1')]),
 
         # Connect merged results to outputs
-        (outputnode, dwi_derivatives_wf,
-          [('merged_image', 'inputnode.dwi_t1'),
-           ('dwi_mask_t1', 'inputnode.dwi_mask_t1'),
-           ('cnr_map_t1', 'inputnode.cnr_map_t1'),
-           ('merged_bval', 'inputnode.bvals_t1'),
-           ('bvecs_t1', 'inputnode.bvecs_t1'),
-           ('local_bvecs_t1', 'inputnode.local_bvecs_t1'),
-           ('t1_b0_ref', 'inputnode.t1_b0_ref'),
-           ('gradient_table_t1', 'inputnode.gradient_table_t1'),
-           ('confounds', 'inputnode.confounds'),
-           ('hmc_optimization_data', 'inputnode.hmc_optimization_data')
-          ]),
+        (outputnode, dwi_derivatives_wf, [
+            ('merged_image', 'inputnode.dwi_t1'),
+            ('dwi_mask_t1', 'inputnode.dwi_mask_t1'),
+            ('cnr_map_t1', 'inputnode.cnr_map_t1'),
+            ('merged_bval', 'inputnode.bvals_t1'),
+            ('bvecs_t1', 'inputnode.bvecs_t1'),
+            ('local_bvecs_t1', 'inputnode.local_bvecs_t1'),
+            ('t1_b0_ref', 'inputnode.t1_b0_ref'),
+            ('gradient_table_t1', 'inputnode.gradient_table_t1'),
+            ('confounds', 'inputnode.confounds'),
+            ('hmc_optimization_data', 'inputnode.hmc_optimization_data')]),
     ])
 
     # Fill-in datasinks of reportlets seen so far

--- a/qsiprep/workflows/dwi/distortion_group_merge.py
+++ b/qsiprep/workflows/dwi/distortion_group_merge.py
@@ -72,7 +72,7 @@ def init_distortion_group_merge_wf(merging_strategy, inputs_list, hmc_model, rep
     workflow = Workflow(name=name)
     sanitized_inputs = [name.replace('-', '_') for name in inputs_list]
     input_names = []
-    for suffix in ["_image", "_bval", "_bvec", "_original_bvec", "_b0_ref"
+    for suffix in ["_image", "_bval", "_bvec", "_original_bvec", "_b0_ref",
                    "_original_image", "_raw_concatenated_image"]:
         input_names += [name + suffix for name in sanitized_inputs]
     inputnode = pe.Node(niu.IdentityInterface(fields=input_names), name='inputnode')
@@ -101,7 +101,8 @@ def init_distortion_group_merge_wf(merging_strategy, inputs_list, hmc_model, rep
             (inputnode, merge_original_image, [(input_name + "_original_image",
                                                 merge_input_name)]),
             (inputnode, merge_raw_concatenated_image, [(input_name + "_raw_concatenated_image",
-                                                        merge_input_name)])
+                                                        merge_input_name)]),
+            (inputnode, merge_b0_refs, [(input_name + "_b0_ref", merge_input_name)])
         ])
 
     if merging_strategy.lower() == 'average':
@@ -117,7 +118,8 @@ def init_distortion_group_merge_wf(merging_strategy, inputs_list, hmc_model, rep
         (merge_bval, distortion_merger, [('out', 'bval_files')]),
         (merge_bvec, distortion_merger, [('out', 'bvec_files')]),
         (merge_original_image, distortion_merger, [('out', 'bids_dwi_files')]),
-        (merge_raw_concatenated_image, distortion_merger, [('out', 'raw_concatenated_files')])
+        (merge_raw_concatenated_image, distortion_merger, [('out', 'raw_concatenated_files')]),
+        (merge_b0_refs, distortion_merger, [('out', 'b0_refs')])
     ])
 
     # CONNECT TO DERIVATIVES

--- a/qsiprep/workflows/dwi/distortion_group_merge.py
+++ b/qsiprep/workflows/dwi/distortion_group_merge.py
@@ -1,0 +1,190 @@
+"""
+Merging Distortion Groups
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. autofunction:: init_dwi_hmc_wf
+.. autofunction:: init_dwi_model_hmc_wf
+
+"""
+import logging
+from nipype.interfaces import utility as niu
+import nipype.pipeline.engine as pe
+from .derivatives import init_dwi_derivatives_wf
+from ...engine import Workflow
+from ...interfaces import DerivativesDataSink
+from ...interfaces.mrtrix import MRTrixGradientTable
+from ...interfaces.reports import GradientPlot, SeriesQC
+from ...interfaces.dwi_merge import AveragePEPairs, MergeDWIs
+from .qc import init_mask_overlap_wf
+
+
+DEFAULT_MEMORY_MIN_GB = 0.01
+LOGGER = logging.getLogger('nipype.workflow')
+
+
+def init_distortion_group_merge_wf(merging_strategy, inputs_list, hmc_model, reportlets_dir,
+                                   harmonize_b0_intensities, b0_threshold, output_prefix,
+                                   source_file, output_dir, template, shoreline_iters,
+                                   mem_gb=3, omp_nthreads=1,
+                                   name="distortion_group_merge_wf"):
+    """Create an unbiased intramodal template for a subject. This aligns the b=0 references
+    from all the scans of a subject. Can be rigid, affine or nonlinear (BSplineSyN).
+
+    **Parameters**
+        inputs_list: list of inputs
+            List if identifiers for inputs. There will be bvals, bvecs, niis and original
+            bvecs.
+        merging_strategy: str
+            'average': averages images that originally sampled the same q-space coordinate
+            'concat': concatenates images in the 4th dimension
+
+
+    **Inputs**
+
+        [workflow_name]_image...
+            One input for each volume in each input image.
+        [workflow_name]_bval...
+            One input for each input image. path to the corresponding bval file
+        [workflow_name]_bvec...
+            One input for each input image. path to the corresponding final bvec file
+        [workflow_name]_original_bvec...
+            One input for each input image. Path to the original bvec file
+        [workflow_name]_original_image...
+            One input for each input image. Path to the original dwi file
+        [workflow_name]_raw_concatenated_image
+            One input for each input image. Path to the original images after concatenation
+        [workflow_name]_confounds
+            One input for each input image. Path to the confounds files
+        [workflow_name]_b0_ref
+            One input for each input image. Path to the b=0 reference image
+
+    **Outputs**
+        merged_image
+            The input images merged into a single image (averaged or concatenated)
+        merged_bval
+            The bvals corresponding to merged_image
+        merged_bvec
+            The bvecs corresponding to merged_image
+        merged_qc
+            The Before/After QC file
+
+    """
+    workflow = Workflow(name=name)
+    sanitized_inputs = [name.replace('-', '_') for name in inputs_list]
+    input_names = []
+    for suffix in ["_image", "_bval", "_bvec", "_original_bvec", "_b0_ref"
+                   "_original_image", "_raw_concatenated_image"]:
+        input_names += [name + suffix for name in sanitized_inputs]
+    inputnode = pe.Node(niu.IdentityInterface(fields=input_names), name='inputnode')
+    outputnode = pe.Node(
+        niu.IdentityInterface(fields=["merged_image", "merged_bval", "merged_bvec", "merged_qc"]),
+        name='outputnode')
+
+    num_inputs = len(input_names)
+    merge_images = pe.Node(niu.Merge(num_inputs), name='merge_images')
+    merge_bval = pe.Node(niu.Merge(num_inputs), name='merge_bval')
+    merge_bvec = pe.Node(niu.Merge(num_inputs), name='merge_bvec')
+    merge_original_bvec = pe.Node(niu.Merge(num_inputs), name='merge_original_bvec')
+    merge_original_image = pe.Node(niu.Merge(num_inputs), name='merge_original_image')
+    merge_b0_refs = pe.Node(niu.Merge(num_inputs), name='merge_b0_refs')
+    merge_raw_concatenated_image = pe.Node(niu.Merge(num_inputs),
+                                           name='merge_raw_concatenated_image')
+
+    # Merge the input data from each distortion group: safe even if eddy was used
+    for input_num, input_name in enumerate(sanitized_inputs):
+        merge_input_name = 'in%d' % (input_num + 1)
+        workflow.connect([
+            (inputnode, merge_images, [(input_name + "_image", merge_input_name)]),
+            (inputnode, merge_bval, [(input_name + "_bval", merge_input_name)]),
+            (inputnode, merge_bvec, [(input_name + "_bvec", merge_input_name)]),
+            (inputnode, merge_original_bvec, [(input_name + "_original_bvec", merge_input_name)]),
+            (inputnode, merge_original_image, [(input_name + "_original_image",
+                                                merge_input_name)]),
+            (inputnode, merge_raw_concatenated_image, [(input_name + "_raw_concatenated_image",
+                                                        merge_input_name)])
+        ])
+
+    if merging_strategy.lower() == 'average':
+        distortion_merger = pe.Node(AveragePEPairs(), name='distortion_merger')
+        workflow.connect([
+            (merge_original_bvec, distortion_merger, [('out', 'original_bvec_files')])
+        ])
+    elif merging_strategy.startswith('concat'):
+        distortion_merger = pe.Node(MergeDWIs(), name='distortion_merger')
+
+    workflow.connect([
+        (merge_images, distortion_merger, [('out', 'dwi_files')]),
+        (merge_bval, distortion_merger, [('out', 'bval_files')]),
+        (merge_bvec, distortion_merger, [('out', 'bvec_files')]),
+        (merge_original_image, distortion_merger, [('out', 'bids_dwi_files')]),
+        (merge_raw_concatenated_image, distortion_merger, [('out', 'raw_concatenated_files')])
+    ])
+
+    # CONNECT TO DERIVATIVES
+    gtab_t1 = pe.Node(MRTrixGradientTable(), name='gtab_t1')
+    t1_dice_calc = init_mask_overlap_wf(name='t1_dice_calc')
+    gradient_plot = pe.Node(GradientPlot(), name='gradient_plot', run_without_submitting=True)
+    ds_report_gradients = pe.Node(
+        DerivativesDataSink(suffix='sampling_scheme', source_file=source_file),
+        name='ds_report_gradients', run_without_submitting=True,
+        mem_gb=DEFAULT_MEMORY_MIN_GB)
+
+    dwi_derivatives_wf = init_dwi_derivatives_wf(
+        output_prefix=output_prefix,
+        source_file=source_file,
+        output_dir=output_dir,
+        output_spaces=["T1w"],
+        template=template,
+        write_local_bvecs=False,
+        hmc_model=hmc_model,
+        shoreline_iters=shoreline_iters)
+
+    # Combine all the QC measures for a series QC
+    series_qc = pe.Node(SeriesQC(output_file_name=output_prefix), name='series_qc')
+    ds_series_qc = pe.Node(
+        DerivativesDataSink(desc='ImageQC', suffix='dwi', source_file=source_file,
+                            base_directory=output_dir),
+        name='ds_series_qc', run_without_submitting=True,
+        mem_gb=DEFAULT_MEMORY_MIN_GB)
+
+    workflow.connect([
+        (inputnode, series_qc, [
+            ('raw_qc_file', 'pre_qc'),
+            ('confounds', 'confounds_file')]),
+        (t1_dice_calc, series_qc, [('outputnode.dice_score', 't1_dice_score')]),
+        (series_qc, ds_series_qc, [('series_qc_file', 'in_file')]),
+        (inputnode, dwi_derivatives_wf, [('dwi_files', 'inputnode.source_file')]),
+        (inputnode, outputnode, [('hmc_optimization_data', 'hmc_optimization_data')]),
+        (distortion_merger, series_qc, [('merged_raw_concatenated', 't1_qc')]),
+        (transform_dwis_t1, t1_dice_calc, [
+            ('outputnode.resampled_dwi_mask', 'inputnode.dwi_mask')]),
+        (outputnode, gradient_plot, [('bvecs_t1', 'final_bvec_file')]),
+        (distortion_merger, gtab_t1, [('out_bval', 'bval_file'),
+                                      ('out_bvec', 'bvec_file')]),
+        (inputnode, t1_dice_calc, [
+            ('t1_mask', 'inputnode.anatomical_mask')]),
+        (gtab_t1, outputnode, [('gradient_file', 'gradient_table_t1')]),
+        (outputnode, dwi_derivatives_wf,
+         [('dwi_t1', 'inputnode.dwi_t1'),
+          ('dwi_mask_t1', 'inputnode.dwi_mask_t1'),
+          ('cnr_map_t1', 'inputnode.cnr_map_t1'),
+          ('bvals_t1', 'inputnode.bvals_t1'),
+          ('bvecs_t1', 'inputnode.bvecs_t1'),
+          ('local_bvecs_t1', 'inputnode.local_bvecs_t1'),
+          ('t1_b0_ref', 'inputnode.t1_b0_ref'),
+          ('gradient_table_t1', 'inputnode.gradient_table_t1'),
+          ('confounds', 'inputnode.confounds'),
+          ('hmc_optimization_data', 'inputnode.hmc_optimization_data')]),
+        (distortion_merger, gradient_plot, [
+            ('out_bvec', 'orig_bvec_files'),
+            ('out_bval', 'orig_bval_files'),
+            ('original_images', 'source_files')]),
+        (gradient_plot, ds_report_gradients, [('plot_file', 'in_file')])
+    ])
+
+    # Fill-in datasinks of reportlets seen so far
+    for node in workflow.list_node_names():
+        if node.split('.')[-1].startswith('ds_report'):
+            workflow.get_node(node).inputs.base_directory = reportlets_dir
+
+    return workflow

--- a/qsiprep/workflows/dwi/distortion_group_merge.py
+++ b/qsiprep/workflows/dwi/distortion_group_merge.py
@@ -73,7 +73,7 @@ def init_distortion_group_merge_wf(merging_strategy, inputs_list, hmc_model, rep
     sanitized_inputs = [name.replace('-', '_') for name in inputs_list]
     input_names = []
     for suffix in ["_image", "_bval", "_bvec", "_original_bvec", "_b0_ref",
-                   "_original_image", "_raw_concatenated_image"]:
+                   "_original_image", "_raw_concatenated_image", "_confounds"]:
         input_names += [name + suffix for name in sanitized_inputs]
     inputnode = pe.Node(niu.IdentityInterface(fields=input_names), name='inputnode')
     outputnode = pe.Node(
@@ -89,6 +89,7 @@ def init_distortion_group_merge_wf(merging_strategy, inputs_list, hmc_model, rep
     merge_b0_refs = pe.Node(niu.Merge(num_inputs), name='merge_b0_refs')
     merge_raw_concatenated_image = pe.Node(niu.Merge(num_inputs),
                                            name='merge_raw_concatenated_image')
+    merge_confounds = pe.Node(niu.Merge(num_inputs), name='merge_confounds')
 
     # Merge the input data from each distortion group: safe even if eddy was used
     for input_num, input_name in enumerate(sanitized_inputs):
@@ -102,7 +103,8 @@ def init_distortion_group_merge_wf(merging_strategy, inputs_list, hmc_model, rep
                                                 merge_input_name)]),
             (inputnode, merge_raw_concatenated_image, [(input_name + "_raw_concatenated_image",
                                                         merge_input_name)]),
-            (inputnode, merge_b0_refs, [(input_name + "_b0_ref", merge_input_name)])
+            (inputnode, merge_b0_refs, [(input_name + "_b0_ref", merge_input_name)]),
+            (inputnode, merge_confounds, [(input_name + "_b0_ref", merge_input_name)])
         ])
 
     if merging_strategy.lower() == 'average':
@@ -119,7 +121,8 @@ def init_distortion_group_merge_wf(merging_strategy, inputs_list, hmc_model, rep
         (merge_bvec, distortion_merger, [('out', 'bvec_files')]),
         (merge_original_image, distortion_merger, [('out', 'bids_dwi_files')]),
         (merge_raw_concatenated_image, distortion_merger, [('out', 'raw_concatenated_files')]),
-        (merge_b0_refs, distortion_merger, [('out', 'b0_refs')])
+        (merge_b0_refs, distortion_merger, [('out', 'b0_refs')]),
+        (merge_confounds, distortion_merger, [('out', 'denoising_confounds')])
     ])
 
     # CONNECT TO DERIVATIVES
@@ -150,38 +153,37 @@ def init_distortion_group_merge_wf(merging_strategy, inputs_list, hmc_model, rep
         mem_gb=DEFAULT_MEMORY_MIN_GB)
 
     workflow.connect([
-        (inputnode, series_qc, [
-            ('raw_qc_file', 'pre_qc'),
-            ('confounds', 'confounds_file')]),
-        (t1_dice_calc, series_qc, [('outputnode.dice_score', 't1_dice_score')]),
-        (series_qc, ds_series_qc, [('series_qc_file', 'in_file')]),
-        (inputnode, dwi_derivatives_wf, [('dwi_files', 'inputnode.source_file')]),
-        (inputnode, outputnode, [('hmc_optimization_data', 'hmc_optimization_data')]),
-        (distortion_merger, series_qc, [('merged_raw_concatenated', 't1_qc')]),
-        (transform_dwis_t1, t1_dice_calc, [
-            ('outputnode.resampled_dwi_mask', 'inputnode.dwi_mask')]),
-        (outputnode, gradient_plot, [('bvecs_t1', 'final_bvec_file')]),
-        (distortion_merger, gtab_t1, [('out_bval', 'bval_file'),
-                                      ('out_bvec', 'bvec_file')]),
-        (inputnode, t1_dice_calc, [
-            ('t1_mask', 'inputnode.anatomical_mask')]),
-        (gtab_t1, outputnode, [('gradient_file', 'gradient_table_t1')]),
-        (outputnode, dwi_derivatives_wf,
-         [('dwi_t1', 'inputnode.dwi_t1'),
-          ('dwi_mask_t1', 'inputnode.dwi_mask_t1'),
-          ('cnr_map_t1', 'inputnode.cnr_map_t1'),
-          ('bvals_t1', 'inputnode.bvals_t1'),
-          ('bvecs_t1', 'inputnode.bvecs_t1'),
-          ('local_bvecs_t1', 'inputnode.local_bvecs_t1'),
-          ('t1_b0_ref', 'inputnode.t1_b0_ref'),
-          ('gradient_table_t1', 'inputnode.gradient_table_t1'),
-          ('confounds', 'inputnode.confounds'),
-          ('hmc_optimization_data', 'inputnode.hmc_optimization_data')]),
-        (distortion_merger, gradient_plot, [
-            ('out_bvec', 'orig_bvec_files'),
-            ('out_bval', 'orig_bval_files'),
-            ('original_images', 'source_files')]),
-        (gradient_plot, ds_report_gradients, [('plot_file', 'in_file')])
+        #(inputnode, series_qc, [
+        #    ('raw_qc_file', 'pre_qc'),
+        #    ('confounds', 'confounds_file')]),
+        #(t1_dice_calc, series_qc, [('outputnode.dice_score', 't1_dice_score')]),
+        #(series_qc, ds_series_qc, [('series_qc_file', 'in_file')]),
+        #(inputnode, dwi_derivatives_wf, [('dwi_files', 'inputnode.source_file')]),
+        #(distortion_merger, series_qc, [('merged_raw_concatenated', 't1_qc')]),
+        # (transform_dwis_t1, t1_dice_calc, [
+        #     ('outputnode.resampled_dwi_mask', 'inputnode.dwi_mask')]),
+        # (outputnode, gradient_plot, [('bvecs_t1', 'final_bvec_file')]),
+        #(distortion_merger, gtab_t1, [('out_bval', 'bval_file'),
+        #                              ('out_bvec', 'bvec_file')]),
+        #(inputnode, t1_dice_calc, [
+        #    ('t1_mask', 'inputnode.anatomical_mask')]),
+        #(gtab_t1, outputnode, [('gradient_file', 'gradient_table_t1')]),
+        # (outputnode, dwi_derivatives_wf,
+        #  [('dwi_t1', 'inputnode.dwi_t1'),
+        #   ('dwi_mask_t1', 'inputnode.dwi_mask_t1'),
+        #   ('cnr_map_t1', 'inputnode.cnr_map_t1'),
+        #   ('bvals_t1', 'inputnode.bvals_t1'),
+        #   ('bvecs_t1', 'inputnode.bvecs_t1'),
+        #   ('local_bvecs_t1', 'inputnode.local_bvecs_t1'),
+        #   ('t1_b0_ref', 'inputnode.t1_b0_ref'),
+        #   ('gradient_table_t1', 'inputnode.gradient_table_t1'),
+        #   ('confounds', 'inputnode.confounds'),
+        #   ('hmc_optimization_data', 'inputnode.hmc_optimization_data')]),
+        # (distortion_merger, gradient_plot, [
+        #     ('out_bvec', 'orig_bvec_files'),
+        #     ('out_bval', 'orig_bval_files'),
+        #     ('original_images', 'source_files')]),
+        # (gradient_plot, ds_report_gradients, [('plot_file', 'in_file')])
     ])
 
     # Fill-in datasinks of reportlets seen so far

--- a/qsiprep/workflows/dwi/distortion_group_merge.py
+++ b/qsiprep/workflows/dwi/distortion_group_merge.py
@@ -104,7 +104,7 @@ def init_distortion_group_merge_wf(merging_strategy, inputs_list, hmc_model, rep
             (inputnode, merge_raw_concatenated_image, [(input_name + "_raw_concatenated_image",
                                                         merge_input_name)]),
             (inputnode, merge_b0_refs, [(input_name + "_b0_ref", merge_input_name)]),
-            (inputnode, merge_confounds, [(input_name + "_b0_ref", merge_input_name)])
+            (inputnode, merge_confounds, [(input_name + "_confounds", merge_input_name)])
         ])
 
     if merging_strategy.lower() == 'average':

--- a/qsiprep/workflows/dwi/distortion_group_merge.py
+++ b/qsiprep/workflows/dwi/distortion_group_merge.py
@@ -73,6 +73,7 @@ def init_distortion_group_merge_wf(merging_strategy, inputs_list, hmc_model, rep
 
     """
     workflow = Workflow(name=name)
+    source_file = "dwi/" + source_file
     sanitized_inputs = [name.replace('-', '_') for name in inputs_list]
     input_names = ['t1_brain', 't1_mask', 't1_seg']
     for suffix in ["_image", "_bval", "_bvec", "_original_bvec", "_b0_ref", "_cnr",

--- a/qsiprep/workflows/dwi/finalize.py
+++ b/qsiprep/workflows/dwi/finalize.py
@@ -47,6 +47,7 @@ def init_dwi_finalize_wf(scan_groups,
                          use_syn,
                          make_intramodal_template,
                          source_file,
+                         write_derivatives=True,
                          layout=None):
     """
     This workflow controls the resampling parts of the dwi preprocessing workflow.
@@ -63,7 +64,7 @@ def init_dwi_finalize_wf(scan_groups,
                                   output_dir='.',
                                   output_resolution=2.0,
                                   template='MNI152NLin2009cAsym',
-                                  output_spaces=['T1w', 'template'],
+                                  output_spaces=['T1w'],
                                   low_mem=False,
                                   output_prefix='',
                                   write_local_bvecs=False,
@@ -86,7 +87,6 @@ def init_dwi_finalize_wf(scan_groups,
             Valid spaces:
 
                 - T1w
-                - template
 
         template : str
             Name of template targeted by ``template`` output space
@@ -100,6 +100,10 @@ def init_dwi_finalize_wf(scan_groups,
             Write uncompressed .nii files in some cases to reduce memory usage
         layout : BIDSLayout
             BIDSLayout structure to enable metadata retrieval
+        write_derivatives: bool
+            Is this the final output? If so, write the final derivatives. If these
+            resampled outputs will be combined with other distortion groups at the end,
+            then return the resampled, non-concatenated images
 
     **Inputs**
 
@@ -148,7 +152,8 @@ def init_dwi_finalize_wf(scan_groups,
     **Outputs**
 
         dwi_t1
-            dwi series, resampled to T1w space
+            dwi series, resampled to T1w space. If write_derivitaves, this is a
+            4d file. Otherwise it's a list of resampled images.
         dwi_mask_t1
             dwi series mask in T1w space
         bvals_t1
@@ -158,18 +163,6 @@ def init_dwi_finalize_wf(scan_groups,
         local_bvecs_t1
             voxelwise bvecs accounting for local displacements
         gradient_table_t1
-            MRTrix-style gradient table
-        dwi_mni
-            dwi series, resampled to template space
-        dwi_mask_mni
-            dwi series mask in template space
-        bvals_mni
-            bvalues of the dwi series
-        bvecs_mni
-            bvecs after aligning to the T1w and resampling
-        local_bvecs_mni
-            voxelwise bvecs accounting for local displacements
-        gradient_table_mni
             MRTrix-style gradient table
 
     """
@@ -232,16 +225,11 @@ def init_dwi_finalize_wf(scan_groups,
         ]),
         name='outputnode')
 
-    gradient_plot = pe.Node(GradientPlot(), name='gradient_plot', run_without_submitting=True)
-    ds_report_gradients = pe.Node(
-        DerivativesDataSink(suffix='sampling_scheme', source_file=source_file),
-        name='ds_report_gradients', run_without_submitting=True,
-        mem_gb=DEFAULT_MEMORY_MIN_GB)
-
     if make_intramodal_template:
         b0_to_im_template = pe.Node(SimpleBeforeAfterRPT(), name='b0_to_im_template')
         ds_report_intramodal = pe.Node(
-            DerivativesDataSink(suffix='tointramodal', source_file=source_file),
+            DerivativesDataSink(suffix='tointramodal', source_file=source_file,
+                                base_directory=reportlets_dir),
             name='ds_report_intramodal', run_without_submitting=True,
             mem_gb=DEFAULT_MEMORY_MIN_GB)
         workflow.connect([
@@ -251,7 +239,71 @@ def init_dwi_finalize_wf(scan_groups,
             (b0_to_im_template, ds_report_intramodal, [('out_report', 'in_file')])
         ])
 
+    transform_dwis_t1 = init_dwi_trans_wf(source_file=source_file,
+                                          name='transform_dwis_t1',
+                                          template="ACPC",
+                                          mem_gb=mem_gb['resampled'],
+                                          omp_nthreads=omp_nthreads,
+                                          output_resolution=output_resolution,
+                                          use_compression=False,
+                                          to_mni=False,
+                                          write_local_bvecs=write_local_bvecs,
+                                          concatenate=not write_derivatives)
+    workflow.connect([
+        (inputnode, transform_dwis_t1, [
+            ('b0_indices', 'inputnode.b0_indices'),
+            ('bval_files', 'inputnode.bval_files'),
+            ('bvec_files', 'inputnode.bvec_files'),
+            ('b0_ref_image', 'inputnode.b0_ref_image'),
+            ('cnr_map', 'inputnode.cnr_map'),
+            ('t1_mask', 'inputnode.t1_mask'),
+            ('dwi_mask', 'inputnode.dwi_mask'),
+            ('hmc_xforms', 'inputnode.hmc_xforms'),
+            ('fieldwarps', 'inputnode.fieldwarps'),
+            ('dwi_files', 'inputnode.dwi_files'),
+            ('dwi_sampling_grid', 'inputnode.output_grid'),
+            ('b0_to_intramodal_template_transforms',
+             'inputnode.b0_to_intramodal_template_transforms'),
+            ('intramodal_template_to_t1_affine',
+             'inputnode.intramodal_template_to_t1_affine'),
+            ('intramodal_template_to_t1_warp',
+             'inputnode.intramodal_template_to_t1_warp'),
+            ('itk_b0_to_t1', 'inputnode.itk_b0_to_t1')]),
+        (transform_dwis_t1, outputnode, [('outputnode.bvals', 'bvals_t1'),
+                                         ('outputnode.rotated_bvecs', 'bvecs_t1'),
+                                         ('outputnode.dwi_resampled', 'dwi_t1'),
+                                         ('outputnode.cnr_map_resampled', 'cnr_map_t1'),
+                                         ('outputnode.local_bvecs', 'local_bvecs_t1'),
+                                         ('outputnode.b0_series', 't1_b0_series'),
+                                         ('outputnode.dwi_ref_resampled', 't1_b0_ref'),
+                                         ('outputnode.resampled_dwi_mask', 'dwi_mask_t1'),
+                                         ('outputnode.resampled_qc', 'series_qc_t1')])
+        # (transform_dwis_t1, interactive_report_wf, [
+        #     ('outputnode.dwi_resampled', 'inputnode.processed_dwi_file'),
+        #     ('outputnode.resampled_dwi_mask', 'inputnode.mask_file'),
+        #     ('outputnode.bvals', 'inputnode.bval_file'),
+        #     ('outputnode.rotated_bvecs', 'inputnode.bvec_file')]),
+    ])
+
+    # Fill-in datasinks of reportlets seen so far
+    for node in workflow.list_node_names():
+        if node.split('.')[-1].startswith('ds_report'):
+            workflow.get_node(node).inputs.base_directory = reportlets_dir
+            workflow.get_node(node).inputs.source_file = source_file
+
+    if not write_derivatives:
+        # The list of transformed images is already attached to dwi_t1
+        return workflow
+
     # CONNECT TO DERIVATIVES #####################
+    gtab_t1 = pe.Node(MRTrixGradientTable(), name='gtab_t1')
+    t1_dice_calc = init_mask_overlap_wf(name='t1_dice_calc')
+    gradient_plot = pe.Node(GradientPlot(), name='gradient_plot', run_without_submitting=True)
+    ds_report_gradients = pe.Node(
+        DerivativesDataSink(suffix='sampling_scheme', source_file=source_file),
+        name='ds_report_gradients', run_without_submitting=True,
+        mem_gb=DEFAULT_MEMORY_MIN_GB)
+
     dwi_derivatives_wf = init_dwi_derivatives_wf(
         output_prefix=output_prefix,
         source_file=source_file,
@@ -287,9 +339,19 @@ def init_dwi_finalize_wf(scan_groups,
         (inputnode, series_qc, [
             ('raw_qc_file', 'pre_qc'),
             ('confounds', 'confounds_file')]),
+        (t1_dice_calc, series_qc, [('outputnode.dice_score', 't1_dice_score')]),
         (series_qc, ds_series_qc, [('series_qc_file', 'in_file')]),
         (inputnode, dwi_derivatives_wf, [('dwi_files', 'inputnode.source_file')]),
         (inputnode, outputnode, [('hmc_optimization_data', 'hmc_optimization_data')]),
+        (transform_dwis_t1, series_qc, [('outputnode.resampled_qc', 't1_qc')]),
+        (transform_dwis_t1, t1_dice_calc, [
+            ('outputnode.resampled_dwi_mask', 'inputnode.dwi_mask')]),
+        (outputnode, gradient_plot, [('bvecs_t1', 'final_bvec_file')]),
+        (transform_dwis_t1, gtab_t1, [('outputnode.bvals', 'bval_file'),
+                                      ('outputnode.rotated_bvecs', 'bvec_file')]),
+        (inputnode, t1_dice_calc, [
+            ('t1_mask', 'inputnode.anatomical_mask')]),
+        (gtab_t1, outputnode, [('gradient_file', 'gradient_table_t1')]),
         (outputnode, dwi_derivatives_wf,
          [('dwi_t1', 'inputnode.dwi_t1'),
           ('dwi_mask_t1', 'inputnode.dwi_mask_t1'),
@@ -308,10 +370,7 @@ def init_dwi_finalize_wf(scan_groups,
           ('mni_b0_ref', 'inputnode.mni_b0_ref'),
           ('gradient_table_mni', 'inputnode.gradient_table_mni'),
           ('confounds', 'inputnode.confounds'),
-          ('hmc_optimization_data', 'inputnode.hmc_optimization_data')])
-    ])
-
-    workflow.connect([
+          ('hmc_optimization_data', 'inputnode.hmc_optimization_data')]),
         (inputnode, gradient_plot, [
             ('bvec_files', 'orig_bvec_files'),
             ('bval_files', 'orig_bval_files'),
@@ -319,118 +378,4 @@ def init_dwi_finalize_wf(scan_groups,
         (gradient_plot, ds_report_gradients, [('plot_file', 'in_file')])
     ])
 
-    if "T1w" in output_spaces:
-        transform_dwis_t1 = init_dwi_trans_wf(source_file=source_file,
-                                              name='transform_dwis_t1',
-                                              template="ACPC",
-                                              mem_gb=mem_gb['resampled'],
-                                              omp_nthreads=omp_nthreads,
-                                              output_resolution=output_resolution,
-                                              use_compression=False,
-                                              to_mni=False,
-                                              write_local_bvecs=write_local_bvecs)
-        gtab_t1 = pe.Node(MRTrixGradientTable(), name='gtab_t1')
-        t1_dice_calc = init_mask_overlap_wf(name='t1_dice_calc')
-        workflow.connect([
-            (inputnode, transform_dwis_t1, [
-                ('b0_indices', 'inputnode.b0_indices'),
-                ('bval_files', 'inputnode.bval_files'),
-                ('bvec_files', 'inputnode.bvec_files'),
-                ('b0_ref_image', 'inputnode.b0_ref_image'),
-                ('cnr_map', 'inputnode.cnr_map'),
-                ('t1_mask', 'inputnode.t1_mask'),
-                ('dwi_mask', 'inputnode.dwi_mask'),
-                ('hmc_xforms', 'inputnode.hmc_xforms'),
-                ('fieldwarps', 'inputnode.fieldwarps'),
-                ('dwi_files', 'inputnode.dwi_files'),
-                ('dwi_sampling_grid', 'inputnode.output_grid'),
-                ('b0_to_intramodal_template_transforms',
-                 'inputnode.b0_to_intramodal_template_transforms'),
-                ('intramodal_template_to_t1_affine',
-                 'inputnode.intramodal_template_to_t1_affine'),
-                ('intramodal_template_to_t1_warp',
-                 'inputnode.intramodal_template_to_t1_warp'),
-                ('itk_b0_to_t1', 'inputnode.itk_b0_to_t1')]),
-            (transform_dwis_t1, outputnode, [('outputnode.bvals', 'bvals_t1'),
-                                             ('outputnode.rotated_bvecs', 'bvecs_t1'),
-                                             ('outputnode.dwi_resampled', 'dwi_t1'),
-                                             ('outputnode.cnr_map_resampled', 'cnr_map_t1'),
-                                             ('outputnode.local_bvecs', 'local_bvecs_t1'),
-                                             ('outputnode.b0_series', 't1_b0_series'),
-                                             ('outputnode.dwi_ref_resampled', 't1_b0_ref'),
-                                             ('outputnode.resampled_dwi_mask', 'dwi_mask_t1'),
-                                             ('outputnode.resampled_qc', 'series_qc_t1')]),
-            (outputnode, gradient_plot, [('bvecs_t1', 'final_bvec_file')]),
-            (transform_dwis_t1, gtab_t1, [('outputnode.bvals', 'bval_file'),
-                                          ('outputnode.rotated_bvecs', 'bvec_file')]),
-            (transform_dwis_t1, series_qc, [('outputnode.resampled_qc', 't1_qc')]),
-            (transform_dwis_t1, t1_dice_calc, [
-                ('outputnode.resampled_dwi_mask', 'inputnode.dwi_mask')]),
-            (inputnode, t1_dice_calc, [
-                ('t1_mask', 'inputnode.anatomical_mask')]),
-            (t1_dice_calc, series_qc, [('outputnode.dice_score', 't1_dice_score')]),
-            # (transform_dwis_t1, interactive_report_wf, [
-            #     ('outputnode.dwi_resampled', 'inputnode.processed_dwi_file'),
-            #     ('outputnode.resampled_dwi_mask', 'inputnode.mask_file'),
-            #     ('outputnode.bvals', 'inputnode.bval_file'),
-            #     ('outputnode.rotated_bvecs', 'inputnode.bvec_file')]),
-            (gtab_t1, outputnode, [('gradient_file', 'gradient_table_t1')])])
-
-    if "template" in output_spaces:
-        transform_dwis_mni = init_dwi_trans_wf(source_file=source_file,
-                                               name='transform_dwis_mni',
-                                               template=template,
-                                               mem_gb=mem_gb['resampled'],
-                                               omp_nthreads=omp_nthreads,
-                                               output_resolution=output_resolution,
-                                               use_compression=False,
-                                               to_mni=True,
-                                               write_local_bvecs=write_local_bvecs)
-        gtab_mni = pe.Node(MRTrixGradientTable(), name='gtab_mni')
-        mni_dice_calc = init_mask_overlap_wf(name='mni_dice_calc')
-        workflow.connect([
-            (inputnode, transform_dwis_mni, [
-                ('b0_indices', 'inputnode.b0_indices'),
-                ('bval_files', 'inputnode.bval_files'),
-                ('bvec_files', 'inputnode.bvec_files'),
-                ('b0_ref_image', 'inputnode.b0_ref_image'),
-                ('cnr_map', 'inputnode.cnr_map'),
-                ('dwi_mask', 'inputnode.dwi_mask'),
-                ('hmc_xforms', 'inputnode.hmc_xforms'),
-                ('fieldwarps', 'inputnode.fieldwarps'),
-                ('dwi_files', 'inputnode.dwi_files'),
-                ('dwi_sampling_grid', 'inputnode.output_grid'),
-                ('b0_to_intramodal_template_transforms',
-                 'inputnode.b0_to_intramodal_template_transforms'),
-                ('intramodal_template_to_t1_affine',
-                 'inputnode.intramodal_template_to_t1_affine'),
-                ('intramodal_template_to_t1_warp',
-                 'inputnode.intramodal_template_to_t1_warp'),
-                ('itk_b0_to_t1', 'inputnode.itk_b0_to_t1'),
-                ('t1_2_mni_forward_transform', 'inputnode.t1_2_mni_forward_transform')]),
-            (transform_dwis_mni, outputnode, [('outputnode.bvals', 'bvals_mni'),
-                                              ('outputnode.rotated_bvecs', 'bvecs_mni'),
-                                              ('outputnode.dwi_resampled', 'dwi_mni'),
-                                              ('outputnode.dwi_mask_resampled', 'dwi_mask_mni'),
-                                              ('outputnode.b0_series', 'mni_b0_series'),
-                                              ('outputnode.local_bvecs', 'local_bvecs_mni'),
-                                              ('outputnode.dwi_ref_resampled', 'mni_b0_ref')]),
-            (transform_dwis_mni, gtab_mni, [('outputnode.bvals', 'bval_file'),
-                                            ('outputnode.rotated_bvecs', 'bvec_file')]),
-            (transform_dwis_mni, series_qc, [('outputnode.resampled_qc', 'mni_qc')]),
-            (transform_dwis_mni, mni_dice_calc, [
-                ('outputnode.resampled_dwi_mask', 'inputnode.dwi_mask')]),
-            (inputnode, mni_dice_calc, [
-                ('mni_mask', 'inputnode.anatomical_mask')]),
-            (mni_dice_calc, series_qc, [('outputnode.dice_score', 'mni_dice_score')]),
-            (gtab_mni, outputnode, [('gradient_file', 'gradient_table_mni')])
-        ])
-        if "T1w" not in output_spaces:
-            workflow.connect([(outputnode, gradient_plot, [('bvecs_mni', 'final_bvec_file')])])
-
-    # Fill-in datasinks of reportlets seen so far
-    for node in workflow.list_node_names():
-        if node.split('.')[-1].startswith('ds_report'):
-            workflow.get_node(node).inputs.base_directory = reportlets_dir
-            workflow.get_node(node).inputs.source_file = source_file
     return workflow

--- a/qsiprep/workflows/dwi/finalize.py
+++ b/qsiprep/workflows/dwi/finalize.py
@@ -248,7 +248,7 @@ def init_dwi_finalize_wf(scan_groups,
                                           use_compression=False,
                                           to_mni=False,
                                           write_local_bvecs=write_local_bvecs,
-                                          concatenate=not write_derivatives)
+                                          concatenate=write_derivatives)
     workflow.connect([
         (inputnode, transform_dwis_t1, [
             ('b0_indices', 'inputnode.b0_indices'),

--- a/qsiprep/workflows/dwi/finalize.py
+++ b/qsiprep/workflows/dwi/finalize.py
@@ -377,5 +377,10 @@ def init_dwi_finalize_wf(scan_groups,
             ('original_files', 'source_files')]),
         (gradient_plot, ds_report_gradients, [('plot_file', 'in_file')])
     ])
+    # Fill-in datasinks of reportlets seen so far
+    for node in workflow.list_node_names():
+        if node.split('.')[-1].startswith('ds_report'):
+            workflow.get_node(node).inputs.base_directory = reportlets_dir
+            workflow.get_node(node).inputs.source_file = source_file
 
     return workflow

--- a/qsiprep/workflows/dwi/merge.py
+++ b/qsiprep/workflows/dwi/merge.py
@@ -196,7 +196,6 @@ def init_merge_and_denoise_wf(raw_dwi_files,
             (merge_dwis, qc_wf, [('out_bval', 'inputnode.bval_file'),
                                  ('out_bvec', 'inputnode.bvec_file')])])
 
-
     # We have denoised and combined, therefore we are done
     if denoise_before_combining:
         workflow.connect([

--- a/qsiprep/workflows/dwi/merge.py
+++ b/qsiprep/workflows/dwi/merge.py
@@ -18,7 +18,7 @@ from .qc import init_modelfree_qc_wf
 from ...interfaces import ConformDwi, DerivativesDataSink
 from ...interfaces.mrtrix import DWIDenoise, DWIBiasCorrect, MRDeGibbs
 from ...interfaces.gradients import ExtractB0s
-from ...interfaces.nilearn import MaskEPI
+from ...interfaces.nilearn import MaskEPI, Merge
 from ...interfaces.dwi_merge import MergeDWIs, StackConfounds
 from ...engine import Workflow
 
@@ -81,7 +81,9 @@ def init_merge_and_denoise_wf(raw_dwi_files,
     **Outputs**
 
         merged_image
-            dwi series, resampled to T1w space
+            dwi series, conformed, denoised if requested
+        merged_raw_image
+            dwi series, conformed, raw
         merged_bval
             bvals from merged images
         merged_bvec
@@ -98,8 +100,9 @@ def init_merge_and_denoise_wf(raw_dwi_files,
     workflow = Workflow(name=name)
     outputnode = pe.Node(
         niu.IdentityInterface(fields=[
-            'merged_image', 'merged_bval', 'merged_bvec', 'noise_images', 'bias_images',
-            'denoising_confounds', 'original_files', 'qc_summary', 'validation_reports']),
+            'merged_image', 'merged_raw_image', 'merged_bval', 'merged_bvec', 'noise_images',
+            'bias_images', 'denoising_confounds', 'original_files', 'qc_summary',
+            'validation_reports']),
         name='outputnode')
 
     # DWIs will be merged at some point.
@@ -113,6 +116,7 @@ def init_merge_and_denoise_wf(raw_dwi_files,
     conformed_bvals = pe.Node(niu.Merge(num_dwis), name='conformed_bvals')
     conformed_bvecs = pe.Node(niu.Merge(num_dwis), name='conformed_bvecs')
     conformed_images = pe.Node(niu.Merge(num_dwis), name='conformed_images')
+    conformed_raw_images = pe.Node(niu.Merge(num_dwis), name='conformed_raw_images')
     conformation_reports = pe.Node(niu.Merge(num_dwis), name='conformation_reports')
     # derivatives from denoising
     denoising_confounds = pe.Node(niu.Merge(num_dwis), name='denoising_confounds')
@@ -159,25 +163,22 @@ def init_merge_and_denoise_wf(raw_dwi_files,
             dwi_source = conformers[-1]
             edge_prefix = ''
 
-        print("merging source", dwi_source)
         workflow.connect([
             (dwi_source, conformed_images, [(edge_prefix + 'dwi_file', 'in%d' % dwi_num)]),
+            (conformers[-1], conformed_raw_images, [('dwi_file', 'in%d' % dwi_num)]),
             (dwi_source, conformed_bvals, [(edge_prefix + 'bval_file', 'in%d' % dwi_num)]),
             (dwi_source, conformed_bvecs, [(edge_prefix + 'bvec_file', 'in%d' % dwi_num)]),
             (conformers[-1], conformation_reports, [('out_report', 'in%d' % dwi_num)])
         ])
 
-    # Get a QC score for the raw data
-    if calculate_qc:
-        qc_wf = init_modelfree_qc_wf(dwi_files=raw_dwi_files)
-        workflow.connect([
-            (qc_wf, outputnode, [('outputnode.qc_summary', 'qc_summary')]),
-            (merge_dwis, qc_wf, [('out_bval', 'inputnode.bval_file'),
-                                 ('out_bvec', 'inputnode.bvec_file')])])
+    # Get an orientation-conformed version of the raw inputs and their gradients
+    raw_merge = pe.Node(Merge(is_dwi=True), name='raw_merge')
 
     # Merge the either conformed-only or conformed-and-denoised data
     workflow.connect([
         (conformed_images, merge_dwis, [('out', 'dwi_files')]),
+        (conformed_raw_images, raw_merge, [('out', 'in_files')]),
+        (raw_merge, outputnode, [('out_file', 'merged_raw_image')]),
         (conformed_bvals, merge_dwis, [('out', 'bval_files')]),
         (conformed_bvecs, merge_dwis, [('out', 'bvec_files')]),
         (conformation_reports, outputnode, [('out', 'validation_reports')]),
@@ -185,6 +186,16 @@ def init_merge_and_denoise_wf(raw_dwi_files,
             ('original_images', 'original_files'),
             ('out_bval', 'merged_bval'),
             ('out_bvec', 'merged_bvec')])])
+
+    # Get a QC score for the raw data
+    if calculate_qc:
+        qc_wf = init_modelfree_qc_wf()
+        workflow.connect([
+            (qc_wf, outputnode, [('outputnode.qc_summary', 'qc_summary')]),
+            (raw_merge, qc_wf, [('out_file', 'inputnode.dwi_file')]),
+            (merge_dwis, qc_wf, [('out_bval', 'inputnode.bval_file'),
+                                 ('out_bvec', 'inputnode.bvec_file')])])
+
 
     # We have denoised and combined, therefore we are done
     if denoise_before_combining:

--- a/qsiprep/workflows/dwi/pre_hmc.py
+++ b/qsiprep/workflows/dwi/pre_hmc.py
@@ -36,6 +36,7 @@ def init_dwi_pre_hmc_wf(scan_groups,
                         omp_nthreads,
                         source_file,
                         low_mem,
+                        calculate_qc=True,
                         name="pre_hmc_wf"):
     """
     This workflow merges and denoises dwi scans. The outputs from this workflow is
@@ -223,12 +224,7 @@ def init_dwi_pre_hmc_wf(scan_groups,
             (pm_bias, outputnode, [
                 ('out', 'bias_images')]),
             (pm_raw_images, raw_rpe_concat, [('out', 'in_files')]),
-            (raw_rpe_concat, outputnode, [('out_file', 'raw_concatenated')]),
-            # (raw_rpe_concat, qc_wf, [('out_file', 'inputnode.dwi_file')]),
-            # (rpe_concat, qc_wf, [
-            #     ('out_bval', 'inputnode.bval_file'),
-            #     ('out_bvec', 'inputnode.bvec_file')]),
-            # (qc_wf, outputnode, [('outputnode.qc_summary', 'qc_file')])
+            (raw_rpe_concat, outputnode, [('out_file', 'raw_concatenated')])
         ])
         workflow.__postdesc__ = "Both groups were then merged into a single file, as required " \
                                 "for the FSL workflows. "
@@ -245,7 +241,6 @@ def init_dwi_pre_hmc_wf(scan_groups,
         orientation=orientation,
         calculate_qc=True,
         source_file=source_file)
-
 
     workflow.connect([
         (merge_dwis, outputnode, [

--- a/qsiprep/workflows/dwi/pre_hmc.py
+++ b/qsiprep/workflows/dwi/pre_hmc.py
@@ -258,11 +258,10 @@ def init_dwi_pre_hmc_wf(scan_groups,
     if calculate_qc:
         qc_wf = init_modelfree_qc_wf(dwi_files=dwi_series)
         workflow.connect([
-        (merge_dwis, qc_wf, [
-            ('outputnode.merged_raw_image', 'inputnode.dwi_file'),
-            ('outputnode.merged_bval', 'inputnode.bval_file'),
-            ('outputnode.merged_bvec', 'inputnode.bvec_file')]),
-        (qc_wf, outputnode, [('outputnode.qc_summary', 'qc_file')])
-    ])
+            (merge_dwis, qc_wf, [
+                ('outputnode.merged_raw_image', 'inputnode.dwi_file'),
+                ('outputnode.merged_bval', 'inputnode.bval_file'),
+                ('outputnode.merged_bvec', 'inputnode.bvec_file')]),
+            (qc_wf, outputnode, [('outputnode.qc_summary', 'qc_file')])])
 
     return workflow

--- a/qsiprep/workflows/dwi/pre_hmc.py
+++ b/qsiprep/workflows/dwi/pre_hmc.py
@@ -251,7 +251,8 @@ def init_dwi_pre_hmc_wf(scan_groups,
             ('outputnode.noise_images', 'noise_images'),
             ('outputnode.validation_reports', 'validation_reports'),
             ('outputnode.denoising_confounds', 'denoising_confounds'),
-            ('outputnode.original_files', 'original_files')])
+            ('outputnode.original_files', 'original_files'),
+            ('outputnode.merged_raw_image', 'raw_concatenated')])
     ])
 
     if calculate_qc:
@@ -261,9 +262,7 @@ def init_dwi_pre_hmc_wf(scan_groups,
             ('outputnode.merged_raw_image', 'inputnode.dwi_file'),
             ('outputnode.merged_bval', 'inputnode.bval_file'),
             ('outputnode.merged_bvec', 'inputnode.bvec_file')]),
-        (qc_wf, outputnode, [
-            ('outputnode.qc_summary', 'qc_file'),
-            ('outputnode.concatenated_data', 'raw_concatenated')])
+        (qc_wf, outputnode, [('outputnode.qc_summary', 'qc_file')])
     ])
 
     return workflow

--- a/qsiprep/workflows/dwi/qc.py
+++ b/qsiprep/workflows/dwi/qc.py
@@ -11,7 +11,6 @@ Utility workflows
 from nipype.pipeline import engine as pe
 from nipype.interfaces import utility as niu, afni
 from ...engine import Workflow
-from ...interfaces.nilearn import Merge
 from ...interfaces.dsi_studio import DSIStudioSrcQC, DSIStudioCreateSrc
 from ...interfaces.reports import InteractiveReport
 from ...interfaces.dipy import TensorReconstruction

--- a/qsiprep/workflows/dwi/resampling.py
+++ b/qsiprep/workflows/dwi/resampling.py
@@ -214,7 +214,7 @@ generating a *preprocessed DWI run in {tpl} space*.
 
     merge = pe.Node(Merge(compress=use_compression), name='merge', mem_gb=mem_gb * 3)
     extract_b0_series = pe.Node(ExtractB0s(), name="extract_b0_series")
-    final_b0_ref = init_dwi_reference_wf(register_t1=False, gen_report=write_reports, 
+    final_b0_ref = init_dwi_reference_wf(register_t1=False, gen_report=write_reports,
                                          desc='resampled', name='final_b0_ref',
                                          source_file=source_file)
 

--- a/qsiprep/workflows/dwi/resampling.py
+++ b/qsiprep/workflows/dwi/resampling.py
@@ -16,7 +16,6 @@ from ...engine import Workflow
 from ...interfaces.nilearn import Merge
 from ...interfaces.gradients import (ComposeTransforms, ExtractB0s, GradientRotation,
                                      LocalGradientRotation)
-from ...interfaces.itk import DisassembleTransform
 from ...interfaces.images import ChooseInterpolator
 from .qc import init_modelfree_qc_wf
 
@@ -31,7 +30,8 @@ def init_dwi_trans_wf(source_file,
                       name='dwi_trans_wf',
                       use_compression=True,
                       to_mni=False,
-                      write_local_bvecs=False):
+                      write_local_bvecs=False,
+                      concatenate=True):
     """
     This workflow samples dwi images to the ``output_grid`` in a "single shot"
     from the original DWI series.
@@ -103,7 +103,8 @@ def init_dwi_trans_wf(source_file,
     **Outputs**
 
         dwi_resampled
-            DWI series, resampled to template space
+            DWI series, resampled to template space. One file if ``concatenate``, otherwise a
+            list of files
         dwi_ref_resampled
             Reference, contrast-enhanced summary of the DWI series, resampled to template space
         dwi_mask_resampled
@@ -163,19 +164,18 @@ generating a *preprocessed DWI run in {tpl} space*.
             'resampled_qc']),
         name='outputnode')
 
-    def _aslist(in_value):
-        if isinstance(in_value, list):
-            return in_value
-        return [in_value]
-
     # get composite warps and composed affines for warping and rotating
     compose_transforms = pe.Node(ComposeTransforms(), name='compose_transforms')
-
-    def _get_first(lll):
-        from nipype.interfaces.base import isdefined
-        if isdefined(lll):
-            return lll[0]
-        return lll
+    get_interpolation = pe.Node(
+        ChooseInterpolator(output_resolution=output_resolution), name='get_interpolation')
+    dwi_transform = pe.MapNode(
+        ants.ApplyTransforms(float=True),
+        name='dwi_transform', iterfield=['input_image', 'transforms'])
+    rotate_gradients = pe.Node(GradientRotation(), name='rotate_gradients')
+    cnr_tfm = pe.Node(
+        ants.ApplyTransforms(interpolation='LanczosWindowedSinc', float=True),
+        name='cnr_tfm',
+        mem_gb=1)
 
     workflow.connect([
         (inputnode, compose_transforms, [
@@ -185,59 +185,10 @@ generating a *preprocessed DWI run in {tpl} space*.
             ('itk_b0_to_t1', 'hmcsdc_dwi_ref_to_t1w_affine'),
             ('fieldwarps', 'fieldwarps'),
             ('b0_to_intramodal_template_transforms', 'b0_to_intramodal_template_transforms'),
-            (('intramodal_template_to_t1_affine', _get_first), 'intramodal_template_to_t1_affine'),
-            ('intramodal_template_to_t1_warp', 'intramodal_template_to_t1_warp'),
-            ])
-    ])
-
-    # Rotate the bvecs
-    rotate_gradients = pe.Node(GradientRotation(), name='rotate_gradients')
-
-    cnr_tfm = pe.Node(
-        ants.ApplyTransforms(interpolation='LanczosWindowedSinc', float=True),
-        name='cnr_tfm',
-        mem_gb=1)
-
-    if to_mni:
-        # Disassemble the to-mni transform if it's a h5 (it should be!)
-        disassemble_mni_xform = pe.Node(DisassembleTransform(), name='disassemble_mni_xform')
-
-        # Write corrected file in the designated output dir
-        mask_merge_tfms = pe.Node(niu.Merge(2), name='mask_merge_tfms',
-                                  run_without_submitting=True,
-                                  mem_gb=DEFAULT_MEMORY_MIN_GB)
-        workflow.connect([
-            (inputnode, disassemble_mni_xform, [('t1_2_mni_forward_transform',
-                                                 'in_file')]),
-            (disassemble_mni_xform, compose_transforms, [('out_transforms',
-                                                          't1_2_mni_forward_transform')]),
-            (inputnode, mask_merge_tfms, [('t1_2_mni_forward_transform', 'in1'),
-                                          (('itk_b0_to_t1', _aslist), 'in2')]),
-            (mask_merge_tfms, cnr_tfm, [('out', 'transforms')])
-        ])
-    else:
-        workflow.connect([
-            (compose_transforms, cnr_tfm, [(('out_warps', _get_first), 'transforms')])
-        ])
-
-    def _get_first(items):
-        return items[0]
-
-    get_interpolation = pe.Node(
-        ChooseInterpolator(output_resolution=output_resolution), name='get_interpolation')
-
-    dwi_transform = pe.MapNode(
-        ants.ApplyTransforms(float=True),
-        name='dwi_transform', iterfield=['input_image', 'transforms'])
-
-    merge = pe.Node(Merge(compress=use_compression), name='merge',
-                    mem_gb=mem_gb * 3)
-
-    extract_b0_series = pe.Node(ExtractB0s(), name="extract_b0_series")
-    final_b0_ref = init_dwi_reference_wf(register_t1=False, gen_report=True, desc='resampled',
-                                         name='final_b0_ref', source_file=source_file)
-
-    workflow.connect([
+            (('intramodal_template_to_t1_affine', _get_first),
+             'intramodal_template_to_t1_affine'),
+            ('intramodal_template_to_t1_warp', 'intramodal_template_to_t1_warp')]),
+        (compose_transforms, cnr_tfm, [(('out_warps', _get_first), 'transforms')]),
         (inputnode, rotate_gradients, [('bvec_files', 'bvec_files'),
                                        ('bval_files', 'bval_files')]),
         (compose_transforms, rotate_gradients, [('out_affines', 'affine_transforms')]),
@@ -247,11 +198,26 @@ generating a *preprocessed DWI run in {tpl} space*.
                               ('output_grid', 'reference_image')]),
         (cnr_tfm, outputnode, [('output_image', 'cnr_map_resampled')]),
         (compose_transforms, dwi_transform, [('out_warps', 'transforms')]),
-        (inputnode, merge, [('name_source', 'header_source')]),
         (inputnode, dwi_transform, [('dwi_files', 'input_image'),
                                     ('output_grid', 'reference_image')]),
         (inputnode, get_interpolation, [('dwi_files', 'dwi_files')]),
         (get_interpolation, dwi_transform, [('interpolation_method', 'interpolation')]),
+    ])
+
+    # If concatenation is not happening here, send the still-split images to outputs
+    if not concatenate:
+        workflow.connect([
+            (dwi_transform, outputnode, [('output_image', 'dwi_resampled')])
+        ])
+        return workflow
+
+    merge = pe.Node(Merge(compress=use_compression), name='merge', mem_gb=mem_gb * 3)
+    extract_b0_series = pe.Node(ExtractB0s(), name="extract_b0_series")
+    final_b0_ref = init_dwi_reference_wf(register_t1=False, gen_report=True, desc='resampled',
+                                         name='final_b0_ref', source_file=source_file)
+
+    workflow.connect([
+        (inputnode, merge, [('name_source', 'header_source')]),
         (dwi_transform, merge, [('output_image', 'in_files')]),
         (merge, outputnode, [('out_file', 'dwi_resampled')]),
         (merge, extract_b0_series, [('out_file', 'dwi_series')]),
@@ -284,3 +250,16 @@ generating a *preprocessed DWI run in {tpl} space*.
 
 def _first(inlist):
     return inlist[0]
+
+
+def _get_first(lll):
+    from nipype.interfaces.base import isdefined
+    if isdefined(lll):
+        return lll[0]
+    return lll
+
+
+def _aslist(in_value):
+    if isinstance(in_value, list):
+        return in_value
+    return [in_value]

--- a/qsiprep/workflows/dwi/resampling.py
+++ b/qsiprep/workflows/dwi/resampling.py
@@ -31,6 +31,7 @@ def init_dwi_trans_wf(source_file,
                       use_compression=True,
                       to_mni=False,
                       write_local_bvecs=False,
+                      write_reports=True,
                       concatenate=True):
     """
     This workflow samples dwi images to the ``output_grid`` in a "single shot"
@@ -213,8 +214,9 @@ generating a *preprocessed DWI run in {tpl} space*.
 
     merge = pe.Node(Merge(compress=use_compression), name='merge', mem_gb=mem_gb * 3)
     extract_b0_series = pe.Node(ExtractB0s(), name="extract_b0_series")
-    final_b0_ref = init_dwi_reference_wf(register_t1=False, gen_report=True, desc='resampled',
-                                         name='final_b0_ref', source_file=source_file)
+    final_b0_ref = init_dwi_reference_wf(register_t1=False, gen_report=write_reports, 
+                                         desc='resampled', name='final_b0_ref',
+                                         source_file=source_file)
 
     workflow.connect([
         (inputnode, merge, [('name_source', 'header_source')]),


### PR DESCRIPTION
The HCP pipelines run the same sampling scheme twice - once in each phase-encoding direction. Each phase-encoding direction version of the scheme is split into two files, resulting in 4 DWI scans. There are also a pair of EPI fieldmaps in the fmaps/ directory.

This PR adds the --distortion-group-merge option that can be 'none' (Default), 'average' (for HCP-style averaging) or 'concat' (produces a 4d series of the corrected input images). 