### PR TITLE
[FIX] Remove outdated `NUMPY_MMAP` calls

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -25,6 +25,11 @@
       "name": "Satterthwaite, Theodore D.",
       "orcid": "0000-0001-7072-9399",
       "type": "Researcher"
+    },
+    {
+      "name": "Magnussen, Fredrik",
+      "affiliation": "Department of Psychology, University of Oslo",
+      "orcid": "0000-0003-2574-1705"
     }
   ],
   "keywords": [

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,5 +1,5 @@
 {
-  "creators": [
+  "contributors": [
     {
       "name": "Cieslak, Matthew",
       "affiliation": "Department of Neuropsychiatry, University of Pennsylvania",
@@ -21,15 +21,14 @@
       "orcid": "0000-0001-7491-9798"
     },
     {
-      "affiliation": "Perelman School of Medicine, University of Pennsylvania, PA, USA",
-      "name": "Satterthwaite, Theodore D.",
-      "orcid": "0000-0001-7072-9399",
-      "type": "Researcher"
-    },
-    {
       "name": "Magnussen, Fredrik",
       "affiliation": "Department of Psychology, University of Oslo",
       "orcid": "0000-0003-2574-1705"
+    },
+    {
+      "affiliation": "Perelman School of Medicine, University of Pennsylvania, PA, USA",
+      "name": "Satterthwaite, Theodore D.",
+      "orcid": "0000-0001-7072-9399"
     }
   ],
   "keywords": [
@@ -40,6 +39,7 @@
     "dMRI",
     "BIDS"
   ],
+  "title": "QSIPrep: An integrative platform for preprocessing and reconstructing diffusion MRI",
   "license": "BSD-3-Clause",
   "upload_type": "software"
 }

--- a/qsiprep/workflows/fieldmap/utils.py
+++ b/qsiprep/workflows/fieldmap/utils.py
@@ -50,7 +50,6 @@ def demean_image(in_file, in_mask=None, out_file=None):
     import numpy as np
     import nibabel as nb
     import os.path as op
-    from nipype.utils import NUMPY_MMAP
 
     if out_file is None:
         fname, fext = op.splitext(op.basename(in_file))
@@ -58,12 +57,12 @@ def demean_image(in_file, in_mask=None, out_file=None):
             fname, _ = op.splitext(fname)
         out_file = op.abspath('./%s_demean.nii.gz' % fname)
 
-    im = nb.load(in_file, mmap=NUMPY_MMAP)
+    im = nb.load(in_file)
     data = im.get_data().astype(np.float32)
     msk = np.ones_like(data)
 
     if in_mask is not None:
-        msk = nb.load(in_mask, mmap=NUMPY_MMAP).get_data().astype(np.float32)
+        msk = nb.load(in_mask).get_data().astype(np.float32)
         msk[msk > 0] = 1.0
         msk[msk < 1] = 0.0
 


### PR DESCRIPTION
This pull request removes the outdated NUMPY_MMAP import from nipype (ref. issue #172).

The other PR, got deleted, since I changed the name of my branch. Sorry for the mess.