### PR TITLE
Updates for Patch2Self

### DIFF
--- a/qsiprep/interfaces/dipy.py
+++ b/qsiprep/interfaces/dipy.py
@@ -103,9 +103,14 @@ class Patch2SelfInputSpec(SeriesPreprocReportInputSpec):
                          desc='Regularization parameter for Ridge and Lasso')
     b0_threshold = traits.Float(50., usedefault=True,
                                 desc='Threshold to segregate b0s')
-    residuals = traits.Bool(True, usedefault=True,
-                            desc='Returns residuals of suppressed noise')
     mask = File(desc='mask image (unused)')
+    b0_denoising = traits.Bool(True, usedefault=True,
+                               desc='denoise the b=0 images too')
+    clip_negative_vals = traits.Bool(True, usedefault=True,
+                                     desc='Sets negative values after denoising to 0')
+    shift_intensity = traits.Bool(False, usedefault=True,
+                                  desc='Shifts the distribution of intensities per '
+                                  'volume to give non-negative values')
     out_report = File('patch2self_report.svg', usedefault=True,
                       desc='filename for the visual report')
 
@@ -163,7 +168,11 @@ class Patch2Self(SeriesPreprocReport, SimpleInterface):
                        alpha=self.inputs.alpha,
                        patch_radius=patch_radius,
                        b0_threshold=self.inputs.b0_threshold,
-                       residuals=self.inputs.residuals)
+                       verbose=True,
+                       b0_denoising=self.inputs.b0_denoising,
+                       clip_negative_vals=self.inputs.clip_negative_vals,
+                       shift_intensity=self.inputs.shift_intensity
+                       )
 
         # Back to nifti
         denoised_img = nb.Nifti1Image(denoised_arr, noisy_img.affine,

--- a/qsiprep/interfaces/patch2self.py
+++ b/qsiprep/interfaces/patch2self.py
@@ -165,7 +165,8 @@ def _extract_3d_patches(arr, patch_radius):
 
 def patch2self(data, bvals, patch_radius=[0, 0, 0], model='ridge',
                b0_threshold=50, out_dtype=None, alpha=1.0, verbose=False,
-               residuals=False):
+               b0_denoising=True, clip_negative_vals=True,
+               shift_intensity=False):
     """ Patch2Self Denoiser
 
     Parameters
@@ -201,10 +202,24 @@ def patch2self(data, bvals, patch_radius=[0, 0, 0], model='ridge',
 
     alpha : float, optional
         Regularization parameter only for ridge regression model.
-        default: 1.0
+        Default: 1.0
 
     verbose : bool, optional
         Show progress of Patch2Self and time taken.
+
+    b0_denoising : bool, optional
+        Skips denoising b0 volumes if set to False.
+        Default: True
+
+    clip_negative_vals : bool, optional
+        Sets negative values after denoising to 0 using `np.clip`.
+        Default: True
+
+    shift_intensity : bool, optional
+        Shifts the distribution of intensities per volume to give
+        non-negative values
+        Default: False
+
 
     Returns
     --------
@@ -218,7 +233,7 @@ def patch2self(data, bvals, patch_radius=[0, 0, 0], model='ridge',
     References
     ----------
 
-    [patch2self] S. Fadnavis, J. Batson, E. Garyfallidis, Patch2Self:
+    [Fadnavis20] S. Fadnavis, J. Batson, E. Garyfallidis, Patch2Self:
                     Denoising Diffusion MRI with Self-supervised Learning,
                     Advances in Neural Information Processing Systems 33 (2020)
     """
@@ -260,9 +275,9 @@ def patch2self(data, bvals, patch_radius=[0, 0, 0], model='ridge',
         t1 = time.time()
 
     # if only 1 b0 volume, skip denoising it
-    if data_b0s.ndim == 3:
-        if verbose is True:
-            print("Only 1 b0 found, b0 denoising skipped...")
+    if data_b0s.ndim == 3 or not b0_denoising:
+        if verbose:
+            print("b0 denoising skipped...")
         denoised_b0s = data_b0s
 
     else:
@@ -318,8 +333,20 @@ def patch2self(data, bvals, patch_radius=[0, 0, 0], model='ridge',
     for i, idx in enumerate(dwi_idx):
         denoised_arr[:, :, :, idx[0]] = np.squeeze(denoised_dwi[..., i])
 
+    # shift intensities per volume to handle for negative intensities
+    if shift_intensity and not clip_negative_vals:
+        for i in range(0, denoised_arr.shape[3]):
+            shift = np.min(data[..., i]) - np.min(denoised_arr[..., i])
+            denoised_arr[..., i] = denoised_arr[..., i] + shift
+
     # clip out the negative values from the denoised output
-    denoised_arr.clip(min=0, out=denoised_arr)
+    elif clip_negative_vals and not shift_intensity:
+        denoised_arr.clip(min=0, out=denoised_arr)
+
+    elif clip_negative_vals and shift_intensity:
+        warn('Both `clip_negative_vals` and `shift_intensity` cannot be True.')
+        warn('Defaulting to `clip_negative_bvals`...')
+        denoised_arr.clip(min=0, out=denoised_arr)
 
     # Calculate a "noise level" image
     noise_level_image = np.sqrt(np.mean((data - denoised_arr) ** 2, axis=3))

--- a/qsiprep/interfaces/patch2self.py
+++ b/qsiprep/interfaces/patch2self.py
@@ -233,9 +233,9 @@ def patch2self(data, bvals, patch_radius=[0, 0, 0], model='ridge',
     References
     ----------
 
-    [Fadnavis20] S. Fadnavis, J. Batson, E. Garyfallidis, Patch2Self:
-                    Denoising Diffusion MRI with Self-supervised Learning,
-                    Advances in Neural Information Processing Systems 33 (2020)
+    [patch2self] S. Fadnavis, J. Batson, E. Garyfallidis, Patch2Self:
+                 Denoising Diffusion MRI with Self-supervised Learning,
+                 Advances in Neural Information Processing Systems 33 (2020)
     """
     patch_radius = np.asarray(patch_radius, dtype=np.int)
 

--- a/qsiprep/interfaces/patch2self.py
+++ b/qsiprep/interfaces/patch2self.py
@@ -271,7 +271,7 @@ def patch2self(data, bvals, patch_radius=[0, 0, 0], model='ridge',
 
     denoised_arr = np.empty((data.shape), dtype=calc_dtype)
 
-    if verbose is True:
+    if verbose:
         t1 = time.time()
 
     # if only 1 b0 volume, skip denoising it
@@ -296,7 +296,7 @@ def patch2self(data, bvals, patch_radius=[0, 0, 0], model='ridge',
                                                       data_b0s.shape,
                                                       alpha=alpha)
 
-            if verbose is True:
+            if verbose:
                 print("Denoised b0 Volume: ", vol_idx)
 
     # Separate denoising for DWI volumes
@@ -317,10 +317,10 @@ def patch2self(data, bvals, patch_radius=[0, 0, 0], model='ridge',
                                                   data_dwi.shape,
                                                   alpha=alpha)
 
-        if verbose is True:
+        if verbose:
             print("Denoised DWI Volume: ", vol_idx)
 
-    if verbose is True:
+    if verbose:
         t2 = time.time()
         print('Total time taken for Patch2Self: ', t2-t1, " seconds")
 

--- a/qsiprep/workflows/dwi/merge.py
+++ b/qsiprep/workflows/dwi/merge.py
@@ -311,7 +311,7 @@ def init_dwi_denoising_wf(dwi_denoise_window,
                 name='denoiser')
         else:
             denoiser = pe.Node(
-                Patch2Self(residuals=True, patch_radius=dwi_denoise_window),
+                Patch2Self(patch_radius=dwi_denoise_window),
                 name='denoiser')
             workflow.connect([
                 (inputnode, denoiser, [('bval_file', 'bval_file')])])


### PR DESCRIPTION
- Better edge case handling for ex-vivo data. Handles negative values in the distribution of the data with shifting per-volume (added as an option) rather than clipping always. Preserves the variance of the intensity distribution.
- New option for skipping b0 denoising in totality. For some data, b0 denoising could get very messy. User may want to switch it off and denoise only DWI volumes.

p.s. These changes are in the merged in the master of DIPY 👍🏽 