### PR TITLE
[FIX] Change interactive reports to work with merged distortion groups

### DIFF
--- a/docs/comparisons.md
+++ b/docs/comparisons.md
@@ -10,6 +10,15 @@ their current feature sets. These other
 
  dMRIPrep exclusively performs preprocessing and is therefore omitted from the [reconstruction](#reconstruction) and [tractography](#tractography) sections.
 
+## Supported Sampling Schemes
+
+|                             | QSIPrep | Tractoflow | PreQual | MRtrix3_connectome | dMRIPrep |
+| --------------------------- | :-----: | :--------: | :-----: | :----------------: | :------: |
+| Single Shell                |    ✔    |     ✔      |    ✔    |         ✔          |    ✔     |
+| Multi Shell                 |    ✔    |     ✔      |    ✔    |         ✔          |    ✔     |
+| Cartesian                   |    ✔    |     ✘      |    ✘    |         ✘          |    ✘     |
+| Random (Compressed Sensing) |    ✔    |     ✘      |    ✘    |         ✘          |    ✘     |
+
 ## Preprocessing
 
 |                                                     | QSIPrep                  | Tractoflow             | PreQual                 | MRtrix3_connectome | dMRIPrep         |

--- a/docs/preprocessing.rst
+++ b/docs/preprocessing.rst
@@ -64,7 +64,7 @@ concatenated. Specifically, image denoising (using ``dwidenoise`` or
 ``patch2self``) can be disabled with ``--denoise-method none``. Gibbs
 unringing (using ``mrdegibbs``) is disabled by default but can be enabled
 with ``--unringing-method mrdegibbs``. B1 bias field correction is applied by
-default (using ``dwibiascorrect``), and can be disabled with the
+default (using ``dwibiascorrect``) and can be disabled with the
 ``--dwi-no-biascorr`` option. The intensity of b=0 images is harmonized
 across scans (i.e. scaled to an average value) by default, but this can be
 turned off using ``--dwi-no-b0-harmonization``.
@@ -82,12 +82,12 @@ Gibbs unringing. B1 bias field correction and b=0 intensity harmonization
 do not have as specific requirements about their inputs so are run last.
 
 The last, and potentially very important decision, is whether the denoising
-operations are applied to each input DWI file individually or whether the
+operations are applied to each input DWI series individually or whether the
 denoising operations are applied to the concatenated input DWI files. At
 present, there is little data to guide this choice. The more volumes
 available, the more data MP-PCA/patch2self have to work with. However, if
 there if the head is in a vastly different location in different scans,
-denoising can be impacted in unpredictable ways.
+denoising might be impacted in unpredictable ways.
 
 Consider MP-PCA. If a voxel contains CSF in one DWI series and the subject
 repositions their head between scans so that the voxel contains corpus

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -147,7 +147,7 @@ together *after* images are concatenated by specifying
 What is happening??
 ===================
 
-While QSIPrep runs with `-v -v`, you will see lots of seemingly-nonsensical output
+While QSIPrep runs with `-v -v`, you will see lots of unintuitive output
 in the terminal like::
 
   [Node] Setting-up "qsiprep_wf.single_subject_PNC_wf.dwi_finalize_acq_realistic_wf.transform_dwis_t1.final_b0_ref.b0ref_reportlet" in "/scratch/qsiprep_wf/single_subject_PNC_wf/dwi_finalize_acq_realistic_wf/transform_dwis_t1/final_b0_ref/b0ref_reportlet".

--- a/docs/reconstruction.rst
+++ b/docs/reconstruction.rst
@@ -17,21 +17,21 @@ Instead of specifying a path to a file you can choose from the following:
 +-------------------------------------+--------------+-------------+---------+-----------------+----------------+
 | Option                              | Requires SDC | MultiShell  |   DSI   | DTI             |  Tractography  |
 +=====================================+==============+=============+=========+=================+================+
-|:ref:`mrtrix_multishell_msmt`        |    Yes       |  Required   |    No   |      No         | Probabilistic  |
+|:ref:`mrtrix_multishell_msmt`        |    Yes       |     Yes     |    No   |      No         | Probabilistic  |
 +-------------------------------------+--------------+-------------+---------+-----------------+----------------+
-|:ref:`mrtrix_multishell_msmt_noACT`  |    No        |  Required   |    No   |      No         | Probabilistic  |
+|:ref:`mrtrix_multishell_msmt_noACT`  |    No        |     Yes     |    No   |      No         | Probabilistic  |
 +-------------------------------------+--------------+-------------+---------+-----------------+----------------+
-|:ref:`mrtrix_singleshell_ss3t`       |    Yes       |  No         |    No   |      Yes        | Probabilistic  |
+|:ref:`mrtrix_singleshell_ss3t`       |    Yes       |     No      |    No   |      Yes        | Probabilistic  |
 +-------------------------------------+--------------+-------------+---------+-----------------+----------------+
-|:ref:`mrtrix_singleshell_ss3t_noACT` |    No        |  No         |    No   |      Yes        | Probabilistic  |
+|:ref:`mrtrix_singleshell_ss3t_noACT` |    No        |     No      |    No   |      Yes        | Probabilistic  |
 +-------------------------------------+--------------+-------------+---------+-----------------+----------------+
-|:ref:`dsi_studio_gqi`                | Recommended  |    Yes      |   Yes   |    Yes*         | Deterministic  |
+|:ref:`dsi_studio_gqi`                | Recommended  |     Yes     |   Yes   |    Yes*         | Deterministic  |
 +-------------------------------------+--------------+-------------+---------+-----------------+----------------+
-|:ref:`dipy_mapmri`                   | Recommended  |    Yes      |   Yes   |      No         |   Both         |
+|:ref:`dipy_mapmri`                   | Recommended  |     Yes     |   Yes   |      No         |   Both         |
 +-------------------------------------+--------------+-------------+---------+-----------------+----------------+
-|:ref:`dipy_3dshore`                  | Recommended  |    Yes      |   Yes   |      No         |   Both         |
+|:ref:`dipy_3dshore`                  | Recommended  |     Yes     |   Yes   |      No         |   Both         |
 +-------------------------------------+--------------+-------------+---------+-----------------+----------------+
-|:ref:`csdsi_3dshore`                 | Recommended  |    Yes      |   Yes   |      No         |   Both         |
+|:ref:`csdsi_3dshore`                 | Recommended  |     Yes     |   Yes   |      No         |   Both         |
 +-------------------------------------+--------------+-------------+---------+-----------------+----------------+
 
 \* Not recommended

--- a/qsiprep/interfaces/anatomical.py
+++ b/qsiprep/interfaces/anatomical.py
@@ -119,7 +119,7 @@ class QsiprepAnatomicalIngress(SimpleInterface):
             "%s/sub-%s_desc-preproc_T1w.nii*" % (anat_root, sub),
             excludes=['space-MNI'])
         if 't1_preproc' not in self._results:
-            raise Exception("Unable to find a preprocessed T1w in %s" % qp_root)
+            LOGGER.warning("Unable to find a preprocessed T1w in %s", qp_root)
         self._get_if_exists(
             't1_csf_probseg',
             "%s/sub-%s*_label-CSF_probseg.nii*" % (anat_root, sub),

--- a/qsiprep/interfaces/bids.py
+++ b/qsiprep/interfaces/bids.py
@@ -84,6 +84,7 @@ class QsiReconIngressOutputSpec(TraitedSpec):
     acq_id = traits.Str()
     rec_id = traits.Str()
     run_id = traits.Str()
+    dir_id = traits.Str()
     bval_file = File(exists=True)
     bvec_file = File(exists=True)
     b_file = File(exists=True)
@@ -115,8 +116,8 @@ class QsiReconIngress(SimpleInterface):
         self._get_if_exists('confounds_file', op.join(out_root, "*confounds.tsv"))
         self._get_if_exists('local_bvec_file', op.join(out_root, fname[:-3]+'bvec.nii*'))
         self._get_if_exists('b_file', op.join(out_root, fname+".b"))
-        self._get_if_exists('mask_file', op.join(out_root, fname[:-11] + 'brain_mask.nii.gz'))
-        self._get_if_exists('dwi_ref', op.join(out_root, fname[:-16] + 'dwiref.nii.gz'))
+        self._get_if_exists('mask_file', op.join(out_root, fname[:-11] + 'brain_mask.nii*'))
+        self._get_if_exists('dwi_ref', op.join(out_root, fname[:-16] + 'dwiref.nii*'))
         self._results['dwi_file'] = self.inputs.dwi_file
 
         # Image QC doesn't include space
@@ -130,31 +131,6 @@ class QsiReconIngress(SimpleInterface):
         # Anat is above ses
         if path_parts[-1].startswith('ses'):
             path_parts.pop()
-        """
-        qp_root = op.sep.join(path_parts)
-        anat_root = op.join(qp_root, 'anat')
-        sub = self._results['subject_id']
-        if space == "space-T1w":
-            self._get_if_exists('tpms', anat_root + "/%s_label-*_probseg.nii*" % sub)
-            self._get_if_exists('t1_brain',
-                '%s/%s_desc-preproc_T1w.nii*' % (anat_root, sub))
-            self._get_if_exists('anat_mask',
-                '%s/%s_desc-brain_mask.nii*' % (anat_root, sub))
-        else:
-            self._get_if_exists('tpms',
-                anat_root + "/%s_space-MNI152NLin2009cAsym_label-CSF_probseg.nii*" % sub,
-                multi_ok=True)
-            self._get_if_exists('seg',
-                '%s/%s_space-MNI152NLin2009cAsym_dseg.nii*' % (anat_root, sub))[0]
-            self._get_if_exists('t1_brain',
-                '%s/%s_space-MNI152NLin2009cAsym_desc-preproc_T1w.nii*' % (anat_root, sub))
-            self._get_if_exists('anat_mask',
-                '%s/%s_space-MNI152NLin2009cAsym_desc-brain_mask.nii*' % (anat_root, sub))
-        self._get_if_exists('t1_2_mni_reverse_transform',
-            '%s/%s_from-MNI152NLin2009cAsym_to-T1w*_xfm.h5' % (anat_root, sub))
-        self._get_if_exists('t1_2_mni_forward_transform',
-            '%s/%s_from-T1w_to-MNI152NLin2009cAsym*_xfm.h5' % (anat_root, sub))
-        """
         return runtime
 
     def _get_if_exists(self, name, pattern, multi_ok=False):

--- a/qsiprep/interfaces/dipy.py
+++ b/qsiprep/interfaces/dipy.py
@@ -281,7 +281,11 @@ class DipyReconInterface(SimpleInterface):
         if not isdefined(self.inputs.mask_file):
             dwi_data = amplitudes_img.get_data()
             LOGGER.warning("Creating an Otsu mask, check that the whole brain is covered.")
-            _, mask_array = median_otsu(dwi_data[..., gtab.b0s_mask], 3, 2)
+            _, mask_array = median_otsu(dwi_data,
+                                        vol_idx=gtab.b0s_mask,
+                                        median_radius=3,
+                                        numpass=2)
+
             # Needed for synthetic data
             mask_array = mask_array * (dwi_data.sum(3) > 0)
             mask_img = nb.Nifti1Image(mask_array.astype(np.float32), amplitudes_img.affine,

--- a/qsiprep/utils/misc.py
+++ b/qsiprep/utils/misc.py
@@ -34,14 +34,12 @@ def fix_multi_source_name(in_files, dwi_only):
     '/path/to/sub-045_T1w.nii.gz'
 
     """
-    print('!' * 1000)
     import os
     from nipype.utils.filemanip import filename_to_list
     base, in_file = os.path.split(filename_to_list(in_files)[0])
     subject_label = in_file.split("_", 1)[0].split("-")[1]
     if dwi_only:
         base = base.replace("/dwi", "/anat")
-    print(base)
     return os.path.join(base, "sub-%s_T1w.nii.gz" % subject_label)
 
 

--- a/qsiprep/workflows/base.py
+++ b/qsiprep/workflows/base.py
@@ -843,6 +843,7 @@ to workflows in *QSIPrep*'s documentation]\
             confounds_name = 'inputnode.{name}_confounds'.format(name=output_wfname)
             b0_ref_name = 'inputnode.{name}_b0_ref'.format(name=output_wfname)
             cnr_name = 'inputnode.{name}_cnr'.format(name=output_wfname)
+            carpetplot_name = 'inputnode.{name}_carpetplot_data'.format(name=output_wfname)
             final_merge_wf = merging_group_workflows[concatenation_scheme[output_fname]]
             workflow.connect([
                 (dwi_finalize_wf, final_merge_wf, [
@@ -856,6 +857,7 @@ to workflows in *QSIPrep*'s documentation]\
                     ('outputnode.raw_concatenated', raw_concatenated_image_name),
                     ('outputnode.original_bvecs', original_bvec_name),
                     ('outputnode.original_files', original_bids_name),
+                    ('outputnode.carpetplot_data', carpetplot_name),
                     ('outputnode.confounds', confounds_name)])
             ])
 

--- a/qsiprep/workflows/dwi/base.py
+++ b/qsiprep/workflows/dwi/base.py
@@ -258,7 +258,6 @@ def init_dwi_preproc_wf(dwi_only,
         * :py:func:`~qsiprep.workflows.dwi.registration.init_dwi_t1_trans_wf`
         * :py:func:`~qsiprep.workflows.dwi.registration.init_dwi_reg_wf`
         * :py:func:`~qsiprep.workflows.dwi.confounds.init_dwi_confounds_wf`
-        * :py:func:`~qsiprep.workflows.dwi.resampling.init_dwi_trans_wf`
 
     """
     # Check the inputs

--- a/qsiprep/workflows/dwi/distortion_group_merge.py
+++ b/qsiprep/workflows/dwi/distortion_group_merge.py
@@ -128,7 +128,7 @@ def init_distortion_group_merge_wf(merging_strategy, inputs_list, hmc_model, rep
         distortion_merger = pe.Node(AveragePEPairs(), name='distortion_merger')
         workflow.connect([
             (merge_original_bvec, distortion_merger, [('out', 'original_bvec_files')]),
-            (merge_carpetplot_data, distortion_merger, [('out', '')])
+            (merge_carpetplot_data, distortion_merger, [('out', 'carpetplot_data')])
         ])
     elif merging_strategy.startswith('concat'):
         distortion_merger = pe.Node(MergeDWIs(), name='distortion_merger')
@@ -242,14 +242,15 @@ def init_distortion_group_merge_wf(merging_strategy, inputs_list, hmc_model, rep
             ('out_dwi', 'inputnode.processed_dwi_file'),
             ('out_bval', 'inputnode.bval_file'),
             ('out_bvec', 'inputnode.bvec_file'),
-        ]),
-        (outputnode, interactive_report_wf, [
-            ('carpetplot_data', 'inputnode.carpetplot_data'),
-            ('confounds', 'inputnode.confounds_file')]),
-        (transform_dwis_t1, interactive_report_wf, [
-            ('outputnode.resampled_dwi_mask', 'inputnode.mask_file')
+            ('merged_carpetplot_data', 'inputnode.carpetplot_data'),
+            ('merged_denoising_confounds', 'inputnode.confounds_file')]),
         (interactive_report_wf, outputnode, [
             ('outputnode.out_report', 'interactive_report')]),
+        (b0_ref_wf, interactive_report_wf, [
+            ('outputnode.dwi_mask', 'inputnode.mask_file')]),
+        (series_qc, interactive_report_wf, [('series_qc_file', 'inputnode.series_qc_file')]),
+        (interactive_report_wf, ds_interactive_report, [
+            ('outputnode.out_report', 'in_file')]),
 
         # Connect merged results to outputs
         (outputnode, dwi_derivatives_wf, [

--- a/qsiprep/workflows/dwi/distortion_group_merge.py
+++ b/qsiprep/workflows/dwi/distortion_group_merge.py
@@ -121,7 +121,8 @@ def init_distortion_group_merge_wf(merging_strategy, inputs_list, hmc_model, rep
             (inputnode, merge_b0_refs, [(input_name + "_b0_ref", merge_input_name)]),
             (inputnode, merge_cnrs, [(input_name + "_cnr", merge_input_name)]),
             (inputnode, merge_confounds, [(input_name + "_confounds", merge_input_name)]),
-            (inputnode, merge_carpetplot_data, [(input_name + "_carpetplot_data", merge_input_name)])
+            (inputnode, merge_carpetplot_data, [
+                (input_name + "_carpetplot_data", merge_input_name)])
         ])
 
     if merging_strategy.lower() == 'average':
@@ -237,7 +238,7 @@ def init_distortion_group_merge_wf(merging_strategy, inputs_list, hmc_model, rep
         (gtab_t1, outputnode, [('gradient_file', 'gradient_table_t1')]),
 
         # Connections for the interactive report
-        (distortion_merger, interactive_report_wf,[
+        (distortion_merger, interactive_report_wf, [
             ('merged_raw_dwi', 'inputnode.raw_dwi_file'),
             ('out_dwi', 'inputnode.processed_dwi_file'),
             ('out_bval', 'inputnode.bval_file'),

--- a/qsiprep/workflows/dwi/distortion_group_merge.py
+++ b/qsiprep/workflows/dwi/distortion_group_merge.py
@@ -18,7 +18,7 @@ from ...interfaces.mrtrix import MRTrixGradientTable
 from ...interfaces.reports import GradientPlot, SeriesQC
 from ...interfaces.dwi_merge import AveragePEPairs, MergeDWIs
 from ...interfaces.nilearn import Merge
-from .qc import init_mask_overlap_wf
+from .qc import init_mask_overlap_wf, init_interactive_report_wf
 
 
 DEFAULT_MEMORY_MIN_GB = 0.01
@@ -60,6 +60,8 @@ def init_distortion_group_merge_wf(merging_strategy, inputs_list, hmc_model, rep
             One input for each input image. Path to the confounds files
         [workflow_name]_b0_ref
             One input for each input image. Path to the b=0 reference image
+        [workflow_name]_carpetplot_data
+            One input for each input image. Path to the hmc carpetplot data
 
     **Outputs**
         merged_image
@@ -70,14 +72,17 @@ def init_distortion_group_merge_wf(merging_strategy, inputs_list, hmc_model, rep
             The bvecs corresponding to merged_image
         merged_qc
             The Before/After QC file
-
+        merged_interactive_report
+            The interactive report data
     """
+
     workflow = Workflow(name=name)
     source_file = "dwi/" + source_file
     sanitized_inputs = [name.replace('-', '_') for name in inputs_list]
     input_names = ['t1_brain', 't1_mask', 't1_seg']
     for suffix in ["_image", "_bval", "_bvec", "_original_bvec", "_b0_ref", "_cnr",
-                   "_original_image", "_raw_concatenated_image", "_confounds"]:
+                   "_carpetplot_data", "_original_image", "_raw_concatenated_image",
+                   "_confounds"]:
         input_names += [name + suffix for name in sanitized_inputs]
     inputnode = pe.Node(niu.IdentityInterface(fields=input_names), name='inputnode')
     outputnode = pe.Node(
@@ -99,6 +104,7 @@ def init_distortion_group_merge_wf(merging_strategy, inputs_list, hmc_model, rep
                                            name='merge_raw_concatenated_image')
     merge_confounds = pe.Node(niu.Merge(num_inputs), name='merge_confounds')
     merge_cnrs = pe.Node(niu.Merge(num_inputs), name='merge_cnrs')
+    merge_carpetplot_data = pe.Node(niu.Merge(num_inputs), name='merge_carpetplot_data')
 
     # Merge the input data from each distortion group: safe even if eddy was used
     for input_num, input_name in enumerate(sanitized_inputs):
@@ -114,13 +120,15 @@ def init_distortion_group_merge_wf(merging_strategy, inputs_list, hmc_model, rep
                                                         merge_input_name)]),
             (inputnode, merge_b0_refs, [(input_name + "_b0_ref", merge_input_name)]),
             (inputnode, merge_cnrs, [(input_name + "_cnr", merge_input_name)]),
-            (inputnode, merge_confounds, [(input_name + "_confounds", merge_input_name)])
+            (inputnode, merge_confounds, [(input_name + "_confounds", merge_input_name)]),
+            (inputnode, merge_carpetplot_data, [(input_name + "_carpetplot_data", merge_input_name)])
         ])
 
     if merging_strategy.lower() == 'average':
         distortion_merger = pe.Node(AveragePEPairs(), name='distortion_merger')
         workflow.connect([
-            (merge_original_bvec, distortion_merger, [('out', 'original_bvec_files')])
+            (merge_original_bvec, distortion_merger, [('out', 'original_bvec_files')]),
+            (merge_carpetplot_data, distortion_merger, [('out', '')])
         ])
     elif merging_strategy.startswith('concat'):
         distortion_merger = pe.Node(MergeDWIs(), name='distortion_merger')
@@ -151,6 +159,13 @@ def init_distortion_group_merge_wf(merging_strategy, inputs_list, hmc_model, rep
         name='ds_series_qc', run_without_submitting=True,
         mem_gb=DEFAULT_MEMORY_MIN_GB)
 
+    interactive_report_wf = init_interactive_report_wf()
+    # Write the interactive report json
+    ds_interactive_report = pe.Node(
+        DerivativesDataSink(suffix='dwiqc', source_file=source_file,
+                            base_directory=output_dir),
+        name='ds_interactive_report', run_without_submitting=True,
+        mem_gb=DEFAULT_MEMORY_MIN_GB)
     # CONNECT TO DERIVATIVES
     gtab_t1 = pe.Node(MRTrixGradientTable(), name='gtab_t1')
     t1_dice_calc = init_mask_overlap_wf(name='t1_dice_calc')
@@ -220,6 +235,21 @@ def init_distortion_group_merge_wf(merging_strategy, inputs_list, hmc_model, rep
         (distortion_merger, gtab_t1, [('out_bval', 'bval_file'),
                                       ('out_bvec', 'bvec_file')]),
         (gtab_t1, outputnode, [('gradient_file', 'gradient_table_t1')]),
+
+        # Connections for the interactive report
+        (distortion_merger, interactive_report_wf,[
+            ('merged_raw_dwi', 'inputnode.raw_dwi_file'),
+            ('out_dwi', 'inputnode.processed_dwi_file'),
+            ('out_bval', 'inputnode.bval_file'),
+            ('out_bvec', 'inputnode.bvec_file'),
+        ]),
+        (outputnode, interactive_report_wf, [
+            ('carpetplot_data', 'inputnode.carpetplot_data'),
+            ('confounds', 'inputnode.confounds_file')]),
+        (transform_dwis_t1, interactive_report_wf, [
+            ('outputnode.resampled_dwi_mask', 'inputnode.mask_file')
+        (interactive_report_wf, outputnode, [
+            ('outputnode.out_report', 'interactive_report')]),
 
         # Connect merged results to outputs
         (outputnode, dwi_derivatives_wf, [

--- a/qsiprep/workflows/dwi/finalize.py
+++ b/qsiprep/workflows/dwi/finalize.py
@@ -246,7 +246,6 @@ def init_dwi_finalize_wf(scan_groups,
                                           to_mni=False,
                                           write_local_bvecs=write_local_bvecs,
                                           concatenate=write_derivatives)
-    interactive_report_wf = init_interactive_report_wf()
 
     workflow.connect([
         (inputnode, transform_dwis_t1, [
@@ -285,9 +284,13 @@ def init_dwi_finalize_wf(scan_groups,
             workflow.get_node(node).inputs.base_directory = reportlets_dir
             workflow.get_node(node).inputs.source_file = source_file
 
+    # The workflow is done if we will be concatenating images later
     if not write_derivatives:
         # The list of transformed images is already attached to dwi_t1
         return workflow
+
+    # Finish up the derivatives process
+    interactive_report_wf = init_interactive_report_wf()
 
     # We need to attach outputs to the interactive report
     workflow.connect([

--- a/qsiprep/workflows/dwi/finalize.py
+++ b/qsiprep/workflows/dwi/finalize.py
@@ -276,17 +276,7 @@ def init_dwi_finalize_wf(scan_groups,
                                          ('outputnode.b0_series', 't1_b0_series'),
                                          ('outputnode.dwi_ref_resampled', 't1_b0_ref'),
                                          ('outputnode.resampled_dwi_mask', 'dwi_mask_t1'),
-                                         ('outputnode.resampled_qc', 'series_qc_t1')]),
-        (inputnode, interactive_report_wf, [
-            ('raw_concatenated', 'inputnode.raw_dwi_file'),
-            ('carpetplot_data', 'inputnode.carpetplot_data'),
-            ('confounds', 'inputnode.confounds_file')]),
-        (transform_dwis_t1, interactive_report_wf, [
-             ('outputnode.dwi_resampled', 'inputnode.processed_dwi_file'),
-             ('outputnode.resampled_dwi_mask', 'inputnode.mask_file'),
-             ('outputnode.bvals', 'inputnode.bval_file'),
-             ('outputnode.rotated_bvecs', 'inputnode.bvec_file')]),
-        (interactive_report_wf, outputnode, [('outputnode.out_report', 'interactive_report')])
+                                         ('outputnode.resampled_qc', 'series_qc_t1')])
     ])
 
     # Fill-in datasinks of reportlets seen so far
@@ -298,6 +288,20 @@ def init_dwi_finalize_wf(scan_groups,
     if not write_derivatives:
         # The list of transformed images is already attached to dwi_t1
         return workflow
+
+    # We need to attach outputs to the interactive report
+    workflow.connect([
+        (inputnode, interactive_report_wf, [
+            ('raw_concatenated', 'inputnode.raw_dwi_file'),
+            ('carpetplot_data', 'inputnode.carpetplot_data'),
+            ('confounds', 'inputnode.confounds_file')]),
+        (transform_dwis_t1, interactive_report_wf, [
+             ('outputnode.dwi_resampled', 'inputnode.processed_dwi_file'),
+             ('outputnode.resampled_dwi_mask', 'inputnode.mask_file'),
+             ('outputnode.bvals', 'inputnode.bval_file'),
+             ('outputnode.rotated_bvecs', 'inputnode.bvec_file')]),
+        (interactive_report_wf, outputnode, [('outputnode.out_report', 'interactive_report')])
+    ])
 
     # CONNECT TO DERIVATIVES #####################
     gtab_t1 = pe.Node(MRTrixGradientTable(), name='gtab_t1')

--- a/qsiprep/workflows/dwi/qc.py
+++ b/qsiprep/workflows/dwi/qc.py
@@ -92,7 +92,7 @@ def init_interactive_report_wf(name="interactive_report_wf"):
     **Outputs**
 
         qc file
-            DSI Studio's src QC metrics for the input data
+            A JSON file that can be opened by dmriprep-viewer
     """
 
     inputnode = pe.Node(

--- a/qsiprep/workflows/recon/base.py
+++ b/qsiprep/workflows/recon/base.py
@@ -168,6 +168,8 @@ def init_single_subject_wf(
                      if 'space-' + space in f.filename]
         LOGGER.info("found %s in %s", dwi_files, recon_input)
 
+        # Find the corresponding mask files
+
     workflow = Workflow('sub-{}_{}'.format(subject_id, spec['name']))
     workflow.__desc__ = """
 Reconstruction was
@@ -206,6 +208,10 @@ to workflows in *qsiprep*'s documentation]\
     else:
         has_transform = False
 
+    t1w_brain_mask = layout.get(subject_id=subject_id, desc='brain', extension=['nii', 'nii.gz'],
+                                modality='anat')
+    has_t1w_brain_mask = bool(t1w_brain_mask)
+
     anat_ingress_wf = init_recon_anatomical_wf(subject_id=subject_id,
                                                recon_input_dir=recon_input,
                                                extras_to_make=spec.get('anatomical', []),
@@ -217,7 +223,8 @@ to workflows in *qsiprep*'s documentation]\
                                            workflow_spec=spec,
                                            reportlets_dir=reportlets_dir,
                                            output_dir=output_dir,
-                                           has_transform=has_transform,
+                                           has_t1w=has_t1w_brain_mask,
+                                           has_t1w_transform=has_transform,
                                            omp_nthreads=omp_nthreads)
     workflow.connect([(anat_ingress_wf, dwi_recon_wf, to_connect)])
 

--- a/qsiprep/workflows/recon/build_workflow.py
+++ b/qsiprep/workflows/recon/build_workflow.py
@@ -228,7 +228,7 @@ def workflow_from_spec(omp_nthreads, has_t1w, has_t1w_transform, node_spec):
     # DSI Studio operations
     if software == "DSI Studio":
         if node_spec["action"] == "reconstruction":
-            return init_dsi_studio_recon_wf(omp_nthreads, has_t1w, has_t1w_transform, **kwargs)
+            return init_dsi_studio_recon_wf(omp_nthreads, has_t1w_transform, **kwargs)
         if node_spec["action"] == "export":
             return init_dsi_studio_export_wf(omp_nthreads, has_t1w_transform, **kwargs)
         if node_spec["action"] == "tractography":

--- a/qsiprep/workflows/recon/build_workflow.py
+++ b/qsiprep/workflows/recon/build_workflow.py
@@ -30,8 +30,8 @@ def _check_repeats(nodelist):
         raise Exception
 
 
-def init_dwi_recon_workflow(dwi_files, workflow_spec, output_dir, reportlets_dir, has_transform,
-                            omp_nthreads, name="recon_wf"):
+def init_dwi_recon_workflow(dwi_files, workflow_spec, output_dir, reportlets_dir, has_t1w,
+                            has_t1w_transform, omp_nthreads, name="recon_wf"):
     """Convert a workflow spec into a nipype workflow.
 
     """
@@ -67,7 +67,7 @@ def init_dwi_recon_workflow(dwi_files, workflow_spec, output_dir, reportlets_dir
         ants.ApplyTransforms(interpolation="MultiLabel", dimension=3),
         name="odf_rois")
     odf_rois.inputs.input_image = crossing_rois_file
-    if has_transform and space == "T1w":
+    if has_t1w_transform and space == "T1w":
         workflow.connect(inputnode, 't1_2_mni_reverse_transform', odf_rois, 'transforms')
     elif space == 'template':
         odf_rois.inputs.transforms = ['identity']
@@ -80,7 +80,7 @@ def init_dwi_recon_workflow(dwi_files, workflow_spec, output_dir, reportlets_dir
     # Save the atlases
     if len(atlas_names) > 0:
         if space == "T1w":
-            if not has_transform:
+            if not has_t1w_transform:
                 LOGGER.critical("No reverse transform found, unable to move atlases"
                                 " into DWI space")
             workflow.connect([
@@ -123,12 +123,14 @@ def init_dwi_recon_workflow(dwi_files, workflow_spec, output_dir, reportlets_dir
                  [(('atlas_configs', _get_resampled, atlas, 'orig_lut'), 'in_file')]),
             ])
         workflow.connect(inputnode, "dwi_file", get_atlases, "reference_image")
+
     # Read nodes from workflow spec, make sure we can implement them
     nodes_to_add = []
     for node_spec in workflow_spec['nodes']:
         if not node_spec['name']:
             raise Exception("Node has no name [{}]".format(node_spec))
-        new_node = workflow_from_spec(omp_nthreads, has_transform or space == 'template',
+        new_node = workflow_from_spec(omp_nthreads, has_t1w,
+                                      has_t1w_transform or space == 'template',
                                       node_spec)
         if new_node is None:
             raise Exception("Unable to create a node for %s" % node_spec)
@@ -210,7 +212,7 @@ def init_dwi_recon_workflow(dwi_files, workflow_spec, output_dir, reportlets_dir
     return workflow
 
 
-def workflow_from_spec(omp_nthreads, has_transform, node_spec):
+def workflow_from_spec(omp_nthreads, has_t1w, has_t1w_transform, node_spec):
     """Build a nipype workflow based on a json file."""
     software = node_spec.get("software", "qsiprep")
     output_suffix = node_spec.get("output_suffix", "")
@@ -226,31 +228,31 @@ def workflow_from_spec(omp_nthreads, has_transform, node_spec):
     # DSI Studio operations
     if software == "DSI Studio":
         if node_spec["action"] == "reconstruction":
-            return init_dsi_studio_recon_wf(omp_nthreads, has_transform, **kwargs)
+            return init_dsi_studio_recon_wf(omp_nthreads, has_t1w, has_t1w_transform, **kwargs)
         if node_spec["action"] == "export":
-            return init_dsi_studio_export_wf(omp_nthreads, has_transform, **kwargs)
+            return init_dsi_studio_export_wf(omp_nthreads, has_t1w_transform, **kwargs)
         if node_spec["action"] == "tractography":
-            return init_dsi_studio_tractography_wf(omp_nthreads, has_transform, **kwargs)
+            return init_dsi_studio_tractography_wf(omp_nthreads, has_t1w_transform, **kwargs)
         if node_spec["action"] == "connectivity":
-            return init_dsi_studio_connectivity_wf(omp_nthreads, has_transform, **kwargs)
+            return init_dsi_studio_connectivity_wf(omp_nthreads, has_t1w_transform, **kwargs)
 
     # MRTrix3 operations
     elif software == "MRTrix3":
         if node_spec["action"] == "csd":
-            return init_mrtrix_csd_recon_wf(omp_nthreads, has_transform, **kwargs)
+            return init_mrtrix_csd_recon_wf(omp_nthreads, has_t1w_transform, **kwargs)
         if node_spec["action"] == "global_tractography":
-            return init_global_tractography_wf(omp_nthreads, has_transform, **kwargs)
+            return init_global_tractography_wf(omp_nthreads, has_t1w_transform, **kwargs)
         if node_spec["action"] == "tractography":
-            return init_mrtrix_tractography_wf(omp_nthreads, has_transform, **kwargs)
+            return init_mrtrix_tractography_wf(omp_nthreads, has_t1w_transform, **kwargs)
         if node_spec["action"] == "connectivity":
-            return init_mrtrix_connectivity_wf(omp_nthreads, has_transform, **kwargs)
+            return init_mrtrix_connectivity_wf(omp_nthreads, has_t1w_transform, **kwargs)
 
     # Dipy operations
     elif software == "Dipy":
         if node_spec["action"] == "3dSHORE_reconstruction":
-            return init_dipy_brainsuite_shore_recon_wf(omp_nthreads, has_transform, **kwargs)
+            return init_dipy_brainsuite_shore_recon_wf(omp_nthreads, has_t1w_transform, **kwargs)
         if node_spec["action"] == "MAPMRI_reconstruction":
-            return init_dipy_mapmri_recon_wf(omp_nthreads, has_transform, **kwargs)
+            return init_dipy_mapmri_recon_wf(omp_nthreads, has_t1w_transform, **kwargs)
 
     # qsiprep operations
     else:

--- a/qsiprep/workflows/recon/dsi_studio.py
+++ b/qsiprep/workflows/recon/dsi_studio.py
@@ -23,7 +23,7 @@ from ...interfaces.reports import ReconPeaksReport, ConnectivityReport
 LOGGER = logging.getLogger('nipype.interface')
 
 
-def init_dsi_studio_recon_wf(omp_nthreads, has_transform, name="dsi_studio_recon",
+def init_dsi_studio_recon_wf(omp_nthreads, has_t1w, has_t1w_transform, name="dsi_studio_recon",
                              output_suffix="", params={}):
     """Reconstructs diffusion data using DSI Studio.
 
@@ -55,6 +55,7 @@ def init_dsi_studio_recon_wf(omp_nthreads, has_transform, name="dsi_studio_recon
     desc = """DSI Studio Reconstruction
 
 : """
+    mask_strategy = params.get("mask_source", "t1w")
     create_src = pe.Node(DSIStudioCreateSrc(), name="create_src")
     romdd = params.get("ratio_of_mean_diffusion_distance", 1.25)
     gqi_recon = pe.Node(
@@ -79,7 +80,7 @@ distance of %02f.""" % romdd
         run_without_submitting=True)
 
     # Plot targeted regions
-    if has_transform:
+    if has_t1w_transform:
         ds_report_odfs = pe.Node(
             ReconDerivativesDataSink(extension='.png',
                                      desc="GQIODF",
@@ -88,19 +89,34 @@ distance of %02f.""" % romdd
             run_without_submitting=True)
         workflow.connect(plot_peaks, 'odf_report', ds_report_odfs, 'in_file')
 
+    if has_t1w and mask_strategy == 't1w':
+        desc += "A brain mask from the T1w image was used for ODF estimation. "
+        workflow.connect([
+            (inputnode, resample_mask, [('t1_brain_mask', 'in_file'),
+                                        ('dwi_file', 'master')]),
+            (resample_mask, gqi_recon, [('out_file', 'mask')]),
+            (resample_mask, plot_peaks, [('out_file', 'mask_file')]),
+        ])
+    elif mask_strategy == 't1w' and not has_t1w:
+        raise Exception("T1w mask is not available. Consider changing masking_strategy.")
+    elif mask_strategy == 'b=0':
+        desc += "A brain mask based on b=0 images was used for ODF estimation. "
+        workflow.connect([
+            (inputnode, gqi_recon, [('mask_file', 'mask')]),
+            (inputnode, plot_peaks, [('mask_file', 'mask_file')])
+        ])
+    elif mask_strategy == 'none':
+        desc += "DSI Studio's automatic masking method was used during ODF estimation. "
+
     workflow.connect([
         (inputnode, create_src, [('dwi_file', 'input_nifti_file'),
                                  ('bval_file', 'input_bvals_file'),
                                  ('bvec_file', 'input_bvecs_file')]),
-        (inputnode, resample_mask, [('t1_brain_mask', 'in_file'),
-                                    ('dwi_file', 'master')]),
         (create_src, gqi_recon, [('output_src', 'input_src_file')]),
-        (resample_mask, gqi_recon, [('out_file', 'mask')]),
         (gqi_recon, outputnode, [('output_fib', 'fibgz')]),
         (gqi_recon, plot_peaks, [('output_fib', 'fib_file')]),
         (inputnode, plot_peaks, [('dwi_ref', 'background_image'),
                                  ('odf_rois', 'odf_rois')]),
-        (resample_mask, plot_peaks, [('out_file', 'mask_file')]),
         (plot_peaks, ds_report_peaks, [('out_report', 'in_file')])
     ])
 
@@ -118,7 +134,8 @@ distance of %02f.""" % romdd
     return workflow
 
 
-def init_dsi_studio_tractography_wf(omp_nthreads, has_transform, name="dsi_studio_tractography",
+def init_dsi_studio_tractography_wf(omp_nthreads, has_t1w_transform,
+                                    name="dsi_studio_tractography",
                                     params={}, output_suffix=""):
     """Calculate streamline-based connectivity matrices using DSI Studio.
 
@@ -200,7 +217,8 @@ def init_dsi_studio_tractography_wf(omp_nthreads, has_transform, name="dsi_studi
     return workflow
 
 
-def init_dsi_studio_connectivity_wf(omp_nthreads, has_transform, name="dsi_studio_connectivity",
+def init_dsi_studio_connectivity_wf(omp_nthreads, has_t1w_transform,
+                                    name="dsi_studio_connectivity",
                                     params={}, output_suffix=""):
     """Calculate streamline-based connectivity matrices using DSI Studio.
 
@@ -292,7 +310,7 @@ def init_dsi_studio_connectivity_wf(omp_nthreads, has_transform, name="dsi_studi
     return workflow
 
 
-def init_dsi_studio_export_wf(omp_nthreads, has_transform, name="dsi_studio_export",
+def init_dsi_studio_export_wf(omp_nthreads, has_t1w_transform, name="dsi_studio_export",
                               params={}, output_suffix=""):
     """Export scalar maps from a DSI Studio fib file into NIfTI files with correct headers.
 


### PR DESCRIPTION
Addresses #232 by averaging the carpetplots and motion parameters so they have the same number of samples as the images.